### PR TITLE
Improve personal fact detection and de-duplication

### DIFF
--- a/backend/models/bellaReminder.js
+++ b/backend/models/bellaReminder.js
@@ -15,6 +15,11 @@ const bellaReminderSchema = new mongoose.Schema({
         type: String,
         required: true
     },
+    canonical: {
+        type: String,
+        default: null,
+        index: true
+    },
     reminderTime: {
         type: Date,
         required: true
@@ -25,6 +30,6 @@ const bellaReminderSchema = new mongoose.Schema({
     }
 });
 
-bellaReminderSchema.index({ userId: 1 });
+bellaReminderSchema.index({ userId: 1, canonical: 1 });
 
 module.exports = mongoose.model('BellaReminder', bellaReminderSchema);


### PR DESCRIPTION
## Summary
- track canonical text in `BellaReminder` schema
- deduplicate manual reminders based on canonical form
- improve `/bellaReminders/analyze` to better identify personal facts and avoid duplicates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845cd1ea6a88322aa4923b7a566845b