### PR TITLE
Fix voice navigation to replace history entry

### DIFF
--- a/CareBell/src/components/Bella.jsx
+++ b/CareBell/src/components/Bella.jsx
@@ -163,7 +163,7 @@ export default function Bella() {
           break;
 
         case 'open_menu':
-          navigate(slot);
+          navigate(`/${slot}`, { replace: true });
           await vapi.send({
             type: 'add-message',
             message: { role: 'system', content: `Say "Opening ${slot.replace('-', ' ')}"` }


### PR DESCRIPTION
## Summary
- navigate to voice-activated pages with replace to avoid stacking history

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845d6f67e7483228edabc122081fcc1