### PR TITLE
Improve Bella fullscreen layout and navigation

### DIFF
--- a/CareBell/src/components/Bella.jsx
+++ b/CareBell/src/components/Bella.jsx
@@ -163,7 +163,8 @@ export default function Bella() {
           break;
 
         case 'open_menu':
-          navigate(slot);
+          navigate(slot, { replace: true });
+          setBellaFullscreen(false);
           await vapi.send({
             type: 'add-message',
             message: { role: 'system', content: `Say "Opening ${slot.replace('-', ' ')}"` }
@@ -269,57 +270,68 @@ export default function Bella() {
     transition mb-4
   `;
 
+  const containerClass = `${
+    bellaFullscreen && isChatOpen ? 'flex-row items-start gap-4' : 'flex-col items-center'
+  } flex w-full`;
+
+  const imageSize = !isChatOpen || bellaFullscreen ? 'w-48 h-48' : 'w-24 h-24';
+
   return (
-    <div className="flex flex-col items-center w-full">
-      {isChatOpen ? (
-        <>
-          <div id="bella-img" className="rounded-full overflow-hidden border-[5px] border-blue-800 mb-2 w-24 h-24">
-            <img src={bella_img} alt="Bella" className="w-full h-full object-cover" />
-          </div>
-          <button onClick={()=>setIsChatOpen(false)} className={chatBtnClass}>
+    <div className={containerClass}>
+      <div className="flex flex-col items-center">
+        <div
+          id="bella-img"
+          className={`rounded-full overflow-hidden border-[5px] border-blue-800 mb-2 ${imageSize}`}
+        >
+          <img src={bella_img} alt="Bella" className="w-full h-full object-cover" />
+        </div>
+        {isChatOpen ? (
+          <button onClick={() => setIsChatOpen(false)} className={chatBtnClass}>
             {t('Bella.closeChat')}
           </button>
-          <div ref={chatRef}
-               className="w-full max-w-md p-4 bg-white rounded-lg shadow overflow-y-auto mb-4 space-y-3"
-               style={{maxHeight:'300px'}}>
-            {messages.map((m,i)=>(
-              <div key={i} className={`flex ${m.speaker==='assistant'?'justify-start':'justify-end'}`}>
-                <div className={`px-4 py-2 rounded-lg ${m.speaker==='assistant'?'bg-blue-900 text-white':'bg-gray-300 text-black'}`}
-                     style={{fontSize:'18px',lineHeight:'1.4'}}>
-                  {m.text}
-                </div>
-              </div>
-            ))}
-          </div>
-        </>
-      ):(
-        <>
-          <div id="bella-img"
-               className="rounded-full overflow-hidden border-[5px] border-blue-800 mb-4 w-48 h-48">
-            <img src={bella_img} alt="Bella" className="w-full h-full object-cover" />
-          </div>
-          {messages.length>0 && (
-            <button onClick={()=>setIsChatOpen(true)} className={chatBtnClass}>
+        ) : (
+          messages.length > 0 && (
+            <button onClick={() => setIsChatOpen(true)} className={chatBtnClass}>
               {t('Bella.openChat')}
             </button>
-          )}
-        </>
-      )}
-      <button onClick={toggleCall} className={btnClass}>
-        <Icon className="mr-2 text-xl"/>
-        {callLabel}
-      </button>
-      <button
-        onClick={() => setBellaFullscreen(!bellaFullscreen)}
-        className={`${btnClass} mt-2`}
-      >
-        {bellaFullscreen ? (
-          <FaCompress className="mr-2 text-xl" />
-        ) : (
-          <FaExpand className="mr-2 text-xl" />
+          )
         )}
-        {bellaFullscreen ? t('Bella.exitFullscreen') : t('Bella.fullscreen')}
-      </button>
+        <button onClick={toggleCall} className={btnClass}>
+          <Icon className="mr-2 text-xl" />
+          {callLabel}
+        </button>
+        <button
+          onClick={() => setBellaFullscreen(!bellaFullscreen)}
+          className={`${btnClass} mt-2`}
+        >
+          {bellaFullscreen ? (
+            <FaCompress className="mr-2 text-xl" />
+          ) : (
+            <FaExpand className="mr-2 text-xl" />
+          )}
+          {bellaFullscreen ? t('Bella.exitFullscreen') : t('Bella.fullscreen')}
+        </button>
+      </div>
+      {isChatOpen && (
+        <div
+          ref={chatRef}
+          className={`${bellaFullscreen ? 'flex-1' : 'w-full max-w-md'} p-4 bg-white rounded-lg shadow overflow-y-auto mb-4 space-y-3`}
+          style={{ maxHeight: bellaFullscreen ? '70vh' : '300px' }}
+        >
+          {messages.map((m, i) => (
+            <div key={i} className={`flex ${m.speaker === 'assistant' ? 'justify-start' : 'justify-end'}`}>
+              <div
+                className={`px-4 py-2 rounded-lg ${
+                  m.speaker === 'assistant' ? 'bg-blue-900 text-white' : 'bg-gray-300 text-black'
+                }`}
+                style={{ fontSize: '18px', lineHeight: '1.4' }}
+              >
+                {m.text}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/CareBell/src/components/Bella.jsx
+++ b/CareBell/src/components/Bella.jsx
@@ -1,7 +1,7 @@
 // src/components/Bella.jsx
 //test
 import React, { useEffect, useState, useRef, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Vapi from '@vapi-ai/web';
 import { FaPhone, FaPhoneSlash, FaExpand, FaCompress } from 'react-icons/fa';
 import bella_img from '../resources/Grafik3a.png';
@@ -13,6 +13,7 @@ export default function Bella() {
   const { t, i18n } = useTranslation();
   const { user, bellaFullscreen, setBellaFullscreen } = useContext(AppContext);
   const navigate   = useNavigate();
+  const location   = useLocation();
 
   const [callStatus, setCallStatus] = useState('ready');   // 'ready' | 'calling' | 'in-call'
   const [messages, setMessages]     = useState([]);
@@ -163,7 +164,7 @@ export default function Bella() {
           break;
 
         case 'open_menu':
-          navigate(slot, { replace: true });
+          navigate(slot, { replace: location.pathname !== '/' });
           setBellaFullscreen(false);
           await vapi.send({
             type: 'add-message',


### PR DESCRIPTION
## Summary
- rework `Bella` component layout so chat expands to the right in fullscreen
- exit fullscreen when voice commands open a menu
- open menus with `replace` navigation to avoid history clutter

## Testing
- `npm ci` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845dffd01a88322b98b3773bd70340f