### PR TITLE
Extend Bella menu knowledge with foods

### DIFF
--- a/CareBell/src/components/Bella.jsx
+++ b/CareBell/src/components/Bella.jsx
@@ -109,6 +109,21 @@ export default function Bella() {
             message: { role: 'system', content: `Remember: ${r.description}` }
           });
         }
+
+        const foodRes = await fetch(`${API}/foods`);
+        if (foodRes.ok) {
+          const foods = await foodRes.json();
+          for (let f of foods) {
+            const ingredients = Array.isArray(f.ingredients) ? f.ingredients.join(', ') : '';
+            await vapi.send({
+              type: 'add-message',
+              message: {
+                role: 'system',
+                content: `Food item: ${f.name}. ${f.description}. Ingredients: ${ingredients}. Barcode: ${f.barcode}`
+              }
+            });
+          }
+        }
       } catch (e) { console.error(e); }
     });
 


### PR DESCRIPTION
## Summary
- preload foods as system messages when Bella call starts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845ed16e5ec8322976c6624adebe2d4