### PR TITLE
Add dark mode support

### DIFF
--- a/CareBell/index.html
+++ b/CareBell/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CareBell</title>
   </head>
-  <body class="bg-gray-100 text-gray-800">
+  <body class="bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/CareBell/src/App.jsx
+++ b/CareBell/src/App.jsx
@@ -1,5 +1,5 @@
 //./src/App.jsx
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 
@@ -27,6 +27,14 @@ export default function App() {
 
   const [user, setUser] = useState(null);
   const [bellaFullscreen, setBellaFullscreen] = useState(false);
+  const [darkMode, setDarkMode] = useState(() =>
+    localStorage.getItem('darkMode') === 'true'
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+    localStorage.setItem('darkMode', darkMode);
+  }, [darkMode]);
 
   useEffect(() => {
     //Set first user as default user
@@ -43,7 +51,7 @@ export default function App() {
   }, []);
 
   return (
-    <AppContext.Provider value={{user, setUser, bellaFullscreen, setBellaFullscreen}}>
+    <AppContext.Provider value={{user, setUser, bellaFullscreen, setBellaFullscreen, darkMode, setDarkMode}}>
     <BrowserRouter>
       <div
         className="
@@ -51,6 +59,7 @@ export default function App() {
           p-4
           h-screen          /* exactly viewport height */
           flex flex-col
+          bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100
         "
         style={{ fontSize: "var(--font-size-base,22px)" }}
       >

--- a/CareBell/src/AppContext.jsx
+++ b/CareBell/src/AppContext.jsx
@@ -5,4 +5,6 @@ export const AppContext = React.createContext({
   setUser: () => {},
   bellaFullscreen: false,
   setBellaFullscreen: () => {},
+  darkMode: false,
+  setDarkMode: () => {},
 });

--- a/CareBell/src/components/Bella.jsx
+++ b/CareBell/src/components/Bella.jsx
@@ -348,7 +348,7 @@ export default function Bella() {
       {isChatOpen && (
         <div
           ref={chatRef}
-          className={`${bellaFullscreen ? 'flex-1' : 'w-full max-w-md'} p-4 bg-white rounded-lg shadow overflow-y-auto mb-4 space-y-3`}
+          className={`${bellaFullscreen ? 'flex-1' : 'w-full max-w-md'} p-4 bg-white dark:bg-gray-800 rounded-lg shadow overflow-y-auto mb-4 space-y-3 dark:text-gray-100`}
           style={{ maxHeight: bellaFullscreen ? '70vh' : '300px' }}
         >
           {messages.map((m, i) => (

--- a/CareBell/src/components/CallContacts.jsx
+++ b/CareBell/src/components/CallContacts.jsx
@@ -125,7 +125,7 @@ export default function CallContacts() {
           <span className="text-xl">🗑️</span>
         </button>
         {menuOpen && (
-          <div className="absolute mt-20 right-96 transform translate-x-4/5 bg-white border border-gray-200 rounded-md shadow-lg z-10">
+          <div className="absolute mt-20 right-96 transform translate-x-4/5 bg-white dark:bg-gray-700 border border-gray-200 rounded-md shadow-lg z-10">
             <ul className="py-1">
               <li>
                 <button
@@ -143,7 +143,7 @@ export default function CallContacts() {
 
       {/* Add form */}
       {isAdding && (
-        <div className="mb-6 max-w-md mx-auto bg-white rounded-2xl shadow-md p-3 space-y-1">
+        <div className="mb-6 max-w-md mx-auto bg-white dark:bg-gray-800 rounded-2xl shadow-md p-3 space-y-1 dark:text-gray-100">
           {[
             {
               lbl: t("CallContacts.fullNameLabel"),
@@ -200,7 +200,7 @@ export default function CallContacts() {
         {visibleContacts.map(c => (
           <label
             key={c._id}
-            className="relative bg-white rounded-3xl shadow-md p-6 flex items-center gap-3"
+            className="relative bg-white dark:bg-gray-800 rounded-3xl shadow-md p-6 flex items-center gap-3 dark:text-gray-100"
           >
             {menuOpen && (
               <input

--- a/CareBell/src/components/Exercise.jsx
+++ b/CareBell/src/components/Exercise.jsx
@@ -245,7 +245,7 @@ function Exercise() {
   };
 
   return (
-    <div className="p-4 max-w-6xl mx-auto bg-white shadow-lg rounded-lg">
+    <div className="p-4 max-w-6xl mx-auto bg-white dark:bg-gray-800 shadow-lg rounded-lg dark:text-gray-100">
       <h1 className="text-4xl font-bold mb-8 text-center text-blue-800">
         {t("Exercise.Library")}
       </h1>
@@ -415,7 +415,7 @@ function Exercise() {
       {/* Exercise Detail Modal */}
       {selectedExercise && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg max-w-3xl w-full max-h-[90vh] overflow-y-auto dark:text-gray-100">
             <div className="p-6">
               <div className="flex justify-between items-center mb-4">
                 <h2 className="text-3xl font-bold text-gray-800">{selectedExercise.name}</h2>

--- a/CareBell/src/components/Header.jsx
+++ b/CareBell/src/components/Header.jsx
@@ -96,9 +96,9 @@ export default function Header() {
 
   return (
     <>
-      <header className="flex justify-between items-center py-4 px-4 border-b border-blue-900 mb-4 bg-slate-200">
+      <header className="flex justify-between items-center py-4 px-4 border-b border-blue-900 mb-4 bg-slate-200 dark:bg-gray-800 dark:text-gray-100">
         {/* Date / Time / Weather */}
-        <div className="flex items-center space-x-6 text-blue-900">
+        <div className="flex items-center space-x-6 text-blue-900 dark:text-blue-200">
           <div className="flex flex-col leading-none">
             <span className="text-lg font-bold">{dateStr}</span>
             <span className="text-xl font-bold">{timeStr}</span>
@@ -138,17 +138,17 @@ export default function Header() {
         <div className="flex items-center space-x-4">
           <button
             onClick={() => setCalendarOpen(o => !o)}
-            className="bg-blue-900 text-yellow-200 p-3 rounded-full hover:bg-blue-800"
+            className="bg-blue-900 text-yellow-200 p-3 rounded-full hover:bg-blue-800 dark:bg-blue-700"
           >
             📅
           </button>
           <button
             onClick={() => setShowSettings(true)}
-            className="bg-blue-900 text-yellow-200 p-3 rounded-full hover:bg-blue-800"
+            className="bg-blue-900 text-yellow-200 p-3 rounded-full hover:bg-blue-800 dark:bg-blue-700"
           >
             ⚙️
           </button>
-          <button className="bg-red-500 text-white py-2 px-4 rounded-xl">
+          <button className="bg-red-500 text-white py-2 px-4 rounded-xl dark:bg-red-600">
             {t("Header.Emergency")}
           </button>
         </div>

--- a/CareBell/src/components/Medication.jsx
+++ b/CareBell/src/components/Medication.jsx
@@ -120,7 +120,7 @@ export default function Medication() {
 
       {/* ADD FORM */}
       {isAdding && (
-        <div className="max-w-md mx-auto bg-white rounded-2xl shadow-md p-6 mb-6 space-y-6">
+        <div className="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-2xl shadow-md p-6 mb-6 space-y-6 dark:text-gray-100">
           {[
             { lbl: t("Medication.MedicationName"), name: "name",        placeholder: "Aspirin" },
             { lbl: t("Medication.dosage"),          name: "dosage",      placeholder: "100 mg" },
@@ -160,7 +160,7 @@ export default function Medication() {
         {meds.map((m, i) => {
           const canTake = !m.taken && isWithinWindow(m.nextDue);
           return (
-            <div key={m._id} className="bg-white rounded-2xl shadow-md p-6 flex flex-col gap-3">
+            <div key={m._id} className="bg-white dark:bg-gray-800 rounded-2xl shadow-md p-6 flex flex-col gap-3 dark:text-gray-100">
               <div className="text-xl font-semibold text-gray-900">{m.name}</div>
               <div className="text-gray-700 text-sm">{t("Medication.dosage")} {m.dosage}</div>
               {m.frequency && <div className="text-gray-700 text-sm">{t("Medication.frequency")} {m.frequency} {t("Medication.hours")}</div>}

--- a/CareBell/src/components/News.jsx
+++ b/CareBell/src/components/News.jsx
@@ -126,7 +126,7 @@ export default function News() {
   const retryFetch = () => fetchTodaysNews();
 
   return (
-    <div className="p-4 max-w-4xl mx-auto bg-white shadow-lg rounded-lg">
+    <div className="p-4 max-w-4xl mx-auto bg-white dark:bg-gray-800 shadow-lg rounded-lg dark:text-gray-100">
       <h1 className="text-4xl font-bold mb-8 text-center text-blue-800">Heute Nachrichten</h1>
       {loading ? (
         <div className="flex flex-col items-center justify-center py-12">
@@ -167,7 +167,7 @@ export default function News() {
                     </button>
                   )}
                 </div>
-                <div className="p-5 bg-white">
+                <div className="p-5 bg-white dark:bg-gray-700">
                   {article.image && (
                     <img src={article.image} alt={article.title} className="w-full h-auto rounded-lg mb-4" onError={e => { e.target.style.display = 'none'; }} />
                   )}

--- a/CareBell/src/components/RightSide.jsx
+++ b/CareBell/src/components/RightSide.jsx
@@ -67,7 +67,7 @@ export default function RightSide() {
   }
 
   return (
-    <div id="rightSide" className={`${widthClass} ${heightClass} px-4 overflow-hidden`}>
+    <div id="rightSide" className={`${widthClass} ${heightClass} px-4 overflow-hidden dark:text-gray-100`}>
       <Routes>
         {/* Main menu */}
         <Route
@@ -92,7 +92,7 @@ export default function RightSide() {
 
         {/* Sub-pages */}
         <Route element={
-          <div className="flex flex-col h-full min-h-0 bg-slate-400 p-4">
+          <div className="flex flex-col h-full min-h-0 bg-slate-400 dark:bg-gray-800 p-4">
             {/* Toolbar */}
             <div className="flex items-center mb-4">
               <button

--- a/CareBell/src/components/SettingsModal.jsx
+++ b/CareBell/src/components/SettingsModal.jsx
@@ -11,7 +11,7 @@ import { API } from "../config";
 
 export default function SettingsModal({ onClose }) {
   const { t, i18n } = useTranslation();
-  const { user, setUser } = useContext(AppContext);
+  const { user, setUser, darkMode, setDarkMode } = useContext(AppContext);
 
   const [scale, setScale] = useState(
     parseFloat(localStorage.getItem("fontScale")) || 1
@@ -52,7 +52,7 @@ export default function SettingsModal({ onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="w-[95%] max-w-md bg-white rounded-3xl shadow-xl p-8 relative">
+      <div className="w-[95%] max-w-md bg-white dark:bg-gray-800 rounded-3xl shadow-xl p-8 relative dark:text-gray-100">
         <button
           onClick={onClose}
           className="absolute top-4 left-4 text-2xl text-gray-600 hover:text-gray-800"
@@ -121,6 +121,22 @@ export default function SettingsModal({ onClose }) {
             />
             <FaRunning className="text-2xl" />
           </div>
+        </section>
+
+        {/* DARK MODE */}
+        <section className="mb-8">
+          <h3 className="text-xl font-semibold mb-3">
+            {t("SettingsModal.darkMode")}
+          </h3>
+          <label className="flex items-center gap-4 cursor-pointer">
+            <span className="flex-1">{darkMode ? 'On' : 'Off'}</span>
+            <input
+              type="checkbox"
+              checked={darkMode}
+              onChange={(e) => setDarkMode(e.target.checked)}
+              className="w-6 h-6"
+            />
+          </label>
         </section>
 
         {/* LANGUAGE & USER SELECTORS */}

--- a/CareBell/src/locales/de.json
+++ b/CareBell/src/locales/de.json
@@ -181,6 +181,7 @@
     "textSize": "Textgröße",
     "volume": "Lautstärke",
     "speakingSpeed": "Sprechgeschwindigkeit",
+    "darkMode": "Dunkelmodus",
     "close": "Schließen",
     "language": "Sprache",
     "User": "Benutzer wechseln",

--- a/CareBell/src/locales/en.json
+++ b/CareBell/src/locales/en.json
@@ -185,6 +185,7 @@
     "textSize": "Text Size",
     "volume": "Volume",
     "speakingSpeed": "Speaking Speed",
+    "darkMode": "Dark Mode",
     "close": "Close",
     "language": "Language",
     "User": "Change User",

--- a/CareBell/src/locales/fi.json
+++ b/CareBell/src/locales/fi.json
@@ -181,6 +181,7 @@
     "textSize": "Tekstin koko",
     "volume": "Äänenvoimakkuus",
     "speakingSpeed": "Puhenopeus",
+    "darkMode": "Tumma tila",
     "close": "Sulje",
     "language": "kieli",
     "User": "Vaihda käyttäjää",

--- a/CareBell/src/locales/he.json
+++ b/CareBell/src/locales/he.json
@@ -183,6 +183,7 @@
     "textSize": "גודל טקסט",
     "volume": "עוצמת קול",
     "speakingSpeed": "מהירות דיבור",
+    "darkMode": "מצב כהה",
     "close": "סגור",
     "language": "בחירת שפה",
     "User": "החלף משתמש",

--- a/CareBell/tailwind.config.cjs
+++ b/CareBell/tailwind.config.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ["./src/**/*.{js,jsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- allow Tailwind dark mode via class strategy
- add dark mode state to context and App
- show dark mode toggle in settings
- apply dark variants to key components and page layout
- provide translations for the new setting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857442b9f708322a46438d4ec8ed49a