### PR TITLE
Add local TTS endpoint using piper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ yarn-error.log*
 # Express server
 /server/logs
 
+# Generated TTS audio
+backend/resources/tts/*
+!backend/resources/tts/.gitkeep
+
 
 
 package-lock.json

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,16 @@
+# Backend API
+
+## Local TTS Support
+
+This backend exposes a `/tts` endpoint that uses [piper-tts](https://github.com/rhasspy/piper) to generate audio files locally. The endpoint expects JSON with `text` and an optional `lang` field (`en` or `de`). It returns a WAV file that can be played on most platforms.
+
+Example using `curl`:
+
+```bash
+curl -X POST http://localhost:4443/tts \
+     -H "Content-Type: application/json" \
+     -d '{"text":"Hello world","lang":"en"}' \
+     --output speech.wav
+```
+
+`piper` must be installed and accessible in the server environment (`pip install piper-tts`). Voice models are downloaded automatically by `piper` on first use. Adjust the language to use a different model.

--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -16,6 +16,7 @@ const newsRoute         = require('../routes/news');
 const exercisesRoute    = require('../routes/exercises');
 const reminderRoute     = require('../routes/reminders');
 const roomsRoute        = require('../routes/rooms');
+const ttsRoute          = require('../routes/tts');
 const resourcesPath = express.static(path.join(__dirname, '..', 'resources'));
 
 // ─── App setup ────────────────────────────────────────────────────────────────
@@ -55,6 +56,7 @@ app.use('/news',         newsRoute);
 app.use('/exercises',    exercisesRoute);
 app.use('/reminders',    reminderRoute);
 app.use('/rooms',        roomsRoute);
+app.use('/tts',          ttsRoute);
 app.use('/resources',    resourcesPath);
 
 app.get('/', (_req, res) => {

--- a/backend/routes/tts.js
+++ b/backend/routes/tts.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const router = express.Router();
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const MODEL_MAP = {
+  en: 'en_US-lessac-medium',
+  de: 'de_DE-thorsten-low',
+  du: 'de_DE-thorsten-low',
+};
+
+const ttsDir = path.join(__dirname, '..', 'resources', 'tts');
+fs.mkdirSync(ttsDir, { recursive: true });
+
+function runPiper(text, lang) {
+  return new Promise((resolve, reject) => {
+    const model = MODEL_MAP[lang] || MODEL_MAP.en;
+    const fileName = `tts-${Date.now()}.wav`;
+    const outPath = path.join(ttsDir, fileName);
+
+    const proc = spawn('piper', [
+      '--model', model,
+      '--output_file', outPath,
+    ]);
+
+    proc.stdin.write(text);
+    proc.stdin.end();
+
+    proc.on('error', reject);
+    proc.on('close', (code) => {
+      if (code === 0) resolve(outPath);
+      else reject(new Error(`piper exited with code ${code}`));
+    });
+  });
+}
+
+router.post('/', async (req, res) => {
+  const { text = '', lang = 'en' } = req.body;
+  if (!text.trim()) return res.status(400).json({ error: 'text is required' });
+
+  try {
+    const outPath = await runPiper(text, lang);
+    res.sendFile(outPath, (err) => {
+      fs.unlink(outPath, () => {});
+      if (err) res.status(500).json({ error: err.message });
+    });
+  } catch (err) {
+    console.error('TTS error:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- ignore generated TTS audio
- document how to use new TTS route
- expose `/tts` Express route backed by piper
- keep empty folder for generated WAV files

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `CareBell` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6857f8cdca988322992d488ab35e316c