### PR TITLE
Add participant status and list features

### DIFF
--- a/CareBell/src/components/WebRTCManager.js
+++ b/CareBell/src/components/WebRTCManager.js
@@ -30,6 +30,7 @@ class WebRTCManager {
     this.connectionState       = 'new';
     this.dataChannel          = null;
     this.onConnectionEstablished = null;
+    this.onMediaStateReceived = null;
 
     // Use the updated RTC config from P2P_CONFIG
     this.rtcConfig = P2P_CONFIG.RTC_CONFIG;
@@ -116,6 +117,10 @@ class WebRTCManager {
         } else if (data.type === 'audio-mute-state' && this.onMuteStateReceived) {
           console.log(`🔇 Received mute state via data channel from ${this.targetUserId}: ${data.isMuted ? 'muted' : 'unmuted'}`);
           this.onMuteStateReceived(data.userId, data.isMuted);
+        } else if (data.message && data.message.type === 'media-state' && this.onMediaStateReceived) {
+          this.onMediaStateReceived(data.message);
+        } else if (data.type === 'media-state' && this.onMediaStateReceived) {
+          this.onMediaStateReceived(data);
         }
       } catch (error) {
         console.error('Error parsing P2P message:', error);
@@ -173,6 +178,17 @@ class WebRTCManager {
     }
     
     return sentViaDataChannel;
+  }
+
+  sendMediaState(audioMuted, videoOff) {
+    const stateMessage = {
+      type: 'media-state',
+      userId: this.userId,
+      audioMuted,
+      videoOff,
+      timestamp: Date.now()
+    };
+    return this.sendP2PMessage(stateMessage);
   }
 
   setupPeerConnectionHandlers() {

--- a/CareBell/src/locales/de.json
+++ b/CareBell/src/locales/de.json
@@ -244,6 +244,8 @@
     "online":"online",
     "s":"",
     "participant":"Teilnehmer",
+    "viewParticipants":"Teilnehmer anzeigen",
+    "hideParticipants":"Teilnehmer verbergen",
     "availableRooms": "Verfügbare Zimmer:",
     "createRoom": "Raum schaffen",
     "Title":"Videoräume"

--- a/CareBell/src/locales/en.json
+++ b/CareBell/src/locales/en.json
@@ -248,6 +248,8 @@
     "online":"online",
     "s":"s",
     "participant":"participant",
+    "viewParticipants":"View Participants",
+    "hideParticipants":"Hide Participants",
     "availableRooms": "Available Rooms:",
     "createRoom": "Create Room",
     "Title":"Video Rooms"

--- a/CareBell/src/locales/fi.json
+++ b/CareBell/src/locales/fi.json
@@ -230,6 +230,8 @@
     "online":"verkossa",
     "s":"",
     "participant":"osallistujia",
+    "viewParticipants":"Näytä osallistujat",
+    "hideParticipants":"Piilota osallistujat",
     "availableRooms": "Huoneet:",
     "createRoom": "Luo huone",
     "Title":"Videohuoneet"

--- a/CareBell/src/locales/he.json
+++ b/CareBell/src/locales/he.json
@@ -245,6 +245,8 @@
     "online":"מחובר/ים",
     "s":"ים/",
     "participant":"משתתף",
+    "viewParticipants":"הצג משתתפים",
+    "hideParticipants":"הסתר משתתפים",
     "availableRooms": ":חדרים זמינים",
     "createRoom": "צור חדר",
     "Title":" חדרי וידאו"


### PR DESCRIPTION
## Summary
- show remote media status for each participant
- broadcast local audio/video state to peers
- toggle participant lists for rooms with `View Participants`
- translate new strings for all locales

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686054be57388322bf8216983530b28e