### PR TITLE
Revamp bella reminders analysis

### DIFF
--- a/CareBell/src/features/Bella.jsx
+++ b/CareBell/src/features/Bella.jsx
@@ -254,6 +254,17 @@ export default function Bella() {
         default:
           console.log('Unhandled intent', intent);
       }
+
+      // queue reminder analysis
+      try {
+        fetch(`${API}/bellaReminders/analyze`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: user.id, text })
+        });
+      } catch (e) {
+        console.error(e);
+      }
     });
 
     vapi.on('error', err => console.error(err));

--- a/CareBell/src/features/Bella.jsx
+++ b/CareBell/src/features/Bella.jsx
@@ -107,14 +107,21 @@ export default function Bella() {
       if (!user?.id) return;
       try {
         const res = await fetch(`${API}/bellaReminders/user/${user.id}`);
-        if (!res.ok) throw new Error(res.statusText);
-        const rems = await res.json();
-        for (let r of rems) {
-          await vapi.send({ //send bella a message as system
-            type: 'add-message',
-            message: { role: 'system', content: `Remember: ${r.description}` }
-          });
-        }
+const rems = await res.json();
+if (rems.length > 0) {
+  // turn each entities object into "key: value" strings
+  const parts = rems.map(r => {
+    const ents = r.entities || {};
+    return Object.entries(ents)
+      .map(([k,v]) => `${k.replace(/_/g,' ')}: ${v}`)
+      .join(', ');
+  });
+      const message = `Remember the following about the user: ${parts.join('; ')}`;
+      await vapi.send({
+        type: 'add-message',
+        message: { role: 'system', content: message }
+      });
+    }
       } catch (e) { console.error(e); }
       try {
         const res = await fetch(`${API}/medications/${user.id}`);

--- a/CareBell/src/features/Bella.jsx
+++ b/CareBell/src/features/Bella.jsx
@@ -257,10 +257,13 @@ export default function Bella() {
 
       // queue reminder analysis
       try {
+        //DEBUG LOG
+        const analyzePayload = { userId: user.id, text };
+        console.log('Sending /analyze request', analyzePayload);
         fetch(`${API}/bellaReminders/analyze`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId: user.id, text })
+          body: JSON.stringify(analyzePayload)
         });
       } catch (e) {
         console.error(e);

--- a/backend/models/bellaReminder.js
+++ b/backend/models/bellaReminder.js
@@ -1,34 +1,44 @@
-// models/bellaReminder.js
-
 const mongoose = require('mongoose');
 
 const bellaReminderSchema = new mongoose.Schema({
-    userId: {
-        type: String,
-        required: true
-    },
-    title: {
-        type: String,
-        required: true
-    },
-    description: {
-        type: String,
-        required: true
-    },
-    reminderTime: {
-        type: Date,
-        required: true
-    },
-    isImportant: {
-        type: Boolean,
-        required: true
-    },
-    embedding: {
-        type: [Number],
-        index: false
-    }
+  userId: {
+    type: String,
+    required: true
+  },
+  title: {
+    type: String,
+    required: true
+  },
+  // no longer required—will omit when saving only category/entities
+  description: {
+    type: String
+  },
+  // new field: store exactly what the model returned
+  category: {
+    type: String,
+    required: true,
+    enum: ['personal_information','private_information','question','other']
+  },
+  // new field: free-form object of extracted entities
+  entities: {
+    type: mongoose.Schema.Types.Mixed
+  },
+  reminderTime: {
+    type: Date,
+    required: true
+  },
+  isImportant: {
+    type: Boolean,
+    required: true
+  },
+  // you can still keep embeddings if you plan to use them later
+  embedding: {
+    type: [Number],
+    index: false
+  }
 });
 
+// index for faster lookups by user
 bellaReminderSchema.index({ userId: 1 });
 
 module.exports = mongoose.model('BellaReminder', bellaReminderSchema);

--- a/backend/models/bellaReminder.js
+++ b/backend/models/bellaReminder.js
@@ -22,6 +22,10 @@ const bellaReminderSchema = new mongoose.Schema({
     isImportant: {
         type: Boolean,
         required: true
+    },
+    embedding: {
+        type: [Number],
+        index: false
     }
 });
 

--- a/backend/routes/bellaReminders.js
+++ b/backend/routes/bellaReminders.js
@@ -85,7 +85,11 @@ router.post('/analyze', async (req, res) => {
     const labels = cls.labels;
     const scores = cls.scores;
     const topLabel = labels[0];
-    console.log(`→ topLabel: ${topLabel} (score ${scores[0].toFixed(3)})`);
+    const isPersonal = topLabel === 'personal info';
+    console.log(
+      `→ classification: ${topLabel} (score ${scores[0].toFixed(3)})`);
+    console.log(
+      `→ result: ${isPersonal ? 'PERSONAL' : 'NOT PERSONAL'}`);
 
     if (topLabel === 'personal info') {
       const embeddingResp = await hf.featureExtraction({

--- a/backend/routes/bellaReminders.js
+++ b/backend/routes/bellaReminders.js
@@ -1,12 +1,22 @@
-// routes/bellaReminders.js
 require('dotenv').config();
 const express = require('express');
-const { HfInference } = require('@huggingface/inference');
+const OpenAI = require('openai').default;
 const router = express.Router();
 const BellaReminder = require('../models/bellaReminder');
 
-const HF_TOKEN = process.env.HF_API_TOKEN;
-const hf = new HfInference(HF_TOKEN);
+// initialize OpenAI SDK
+const openai = new OpenAI({ apiKey: process.env.OPENAI_KEY });
+
+// same sensitive-text guard as before
+const SENSITIVE_KEYWORDS = [
+  'password','ssn','social security','bank account','credit card',
+  'debit card','cvv','cvc','pin','passport','driver license','social number'
+];
+function containsSensitive(text) {
+  const lower = text.toLowerCase();
+  if (/\d{5,}/.test(lower)) return true;
+  return SENSITIVE_KEYWORDS.some(k => lower.includes(k));
+}
 
 // 1) Manually add a reminder
 router.post('/addReminder', async (req, res) => {
@@ -33,100 +43,80 @@ router.get('/user/:userId', async (req, res) => {
   }
 });
 
-const SENSITIVE_KEYWORDS = [
-  'password',
-  'ssn',
-  'social security',
-  'bank account',
-  'credit card',
-  'debit card',
-  'cvv',
-  'cvc',
-  'pin',
-  'passport',
-  'driver license',
-  'social number'
-];
-
-function containsSensitive(text) {
-  const lower = text.toLowerCase();
-  if (/\d{5,}/.test(lower)) return true;
-  return SENSITIVE_KEYWORDS.some(k => lower.includes(k));
-}
-
-function cosineSimilarity(a, b) {
-  let dot = 0, normA = 0, normB = 0;
-  for (let i = 0; i < a.length && i < b.length; i++) {
-    dot += a[i] * b[i];
-    normA += a[i] * a[i];
-    normB += b[i] * b[i];
-  }
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}
-
-// 3) Analyze incoming text and auto-save if classified as personal info
+// 3) Analyze incoming text, classify via OpenAI, and auto-save personal info
 router.post('/analyze', async (req, res) => {
   const { userId, text } = req.body;
   if (!userId || !text) {
     return res.status(400).json({ error: 'userId and text are required' });
   }
 
+  // quick-check for ultra-sensitive content
   if (containsSensitive(text)) {
     return res.json({ saved: false, reason: 'too sensitive' });
   }
 
   try {
-    //DEBUG LOG
     console.log('Received /analyze payload', { userId, text });
-    // use zero-shot classification API
-    const hfRequest = {
-      model: 'facebook/bart-large-mnli',
-      inputs: text,
-      parameters: { candidate_labels: ['personal info', 'question', 'other'] }
-    };
-    console.log('HF zeroShot payload', hfRequest);
-    const cls = await hf.zeroShotClassification(hfRequest);
-    console.log('HF zeroShot response', cls);
 
-    const labels = cls.labels || (Array.isArray(cls) ? cls[0].labels : []);
-    const scores = cls.scores || (Array.isArray(cls) ? cls[0].scores : []);
-    const topLabel = labels[0];
-    const isPersonal = topLabel === 'personal info';
-    console.log(
-      `→ classification: ${topLabel} (score ${scores[0].toFixed(3)})`);
-    console.log(
-      `→ result: ${isPersonal ? 'PERSONAL' : 'NOT PERSONAL'}`);
+    // prompt to enforce strict JSON classification
+    const systemPrompt = `
+You are Bella, an AI companion for seniors. You read one user-supplied string and output valid JSON:
+• "category": one of personal_information, private_information, question, other  
+• If category == personal_information, extract only those details a caretaker must know 
+  (e.g. dementia status, eating_habits, family_names, medical_history, routines, etc.) 
+  into an "entities" object, mapping keys to brief descriptions.
+Example:
+{"category":"personal_information","entities":{"dementia":"mild","eating_habits":"one meal per day","family_names":"Alice, Bob"}}
+For any other category omit "entities". Always return JSON only.
+`.trim();
 
-    if (topLabel === 'personal info') {
-      //DEBUG LOG
-      const embReq = { model: 'sentence-transformers/all-MiniLM-L6-v2', inputs: text };
-      console.log('HF embedding payload', embReq);
-      const embeddingResp = await hf.featureExtraction(embReq);
-      console.log('HF embedding response', embeddingResp);
-      const embedding = Array.isArray(embeddingResp[0]) ? embeddingResp[0] : embeddingResp;
+    // call the Chat API
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user',   content: text }
+      ],
+      temperature: 0
+    });
 
-      const existing = await BellaReminder.find({ userId });
-      const duplicate = existing.some(r =>
-        Array.isArray(r.embedding) && cosineSimilarity(r.embedding, embedding) > 0.85
-      );
-      if (!duplicate) {
-        const title = text.split(/,|\./)[0].trim();
+    // parse the JSON reply
+    const raw = completion.choices[0].message.content;
+    let result;
+    try {
+      result = JSON.parse(raw);
+    } catch (err) {
+      console.error('Invalid JSON from OpenAI:', raw);
+      return res.status(500).json({ error: 'Invalid JSON from classification model' });
+    }
+
+    const { category, entities } = result;
+    console.log('→ classification:', category, entities || '');
+
+    // only auto-save personal_information
+    if (category === 'personal_information') {
+      // avoid duplicates by matching user + category + entities
+      const existing = await BellaReminder.findOne({ userId, category, entities });
+      if (!existing) {
+        // title = extracted name if available, otherwise the category label
+        const title = entities?.name || category;
         const reminder = await BellaReminder.create({
           userId,
           title,
-          description: text,
+          category,
+          entities,
           reminderTime: new Date(),
-          isImportant: true,
-          embedding
+          isImportant: true
         });
         return res.status(201).json({ saved: true, reminder });
       }
+      return res.json({ saved: false, reason: 'duplicate' });
     }
 
-    // Otherwise, nothing to save
-    return res.json({ saved: false });
+    // for all other categories, do not save
+    return res.json({ saved: false, category });
   } catch (err) {
-    console.error('Analysis error:', err.response?.data || err.message);
+    console.error('Analysis error:', err);
     return res.status(500).json({ error: err.message });
   }
 });


### PR DESCRIPTION
## Summary
- detect highly sensitive information before saving Bella reminders
- use HuggingFace zero-shot classification and embeddings to avoid duplicate reminders
- queue reminder analysis from the front-end after each user message
- add `@huggingface/inference` dependency

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `CareBell` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686056458cc483229d1327bcc9f98b1f