### PR TITLE
Add backend support for country-based languages

### DIFF
--- a/backend/lib/language.js
+++ b/backend/lib/language.js
@@ -1,0 +1,94 @@
+const LANGUAGE_CODES = ["en", "de", "fi", "he"];
+const DEFAULT_LANGUAGE = "en";
+
+const COUNTRY_LANGUAGE_MAP = {
+  DE: { default: "de", languages: ["de", "en"] },
+  FI: { default: "fi", languages: ["fi", "en"] },
+  IL: { default: "he", languages: ["he", "en"] },
+};
+
+function getCountryConfig(countryCode) {
+  if (!countryCode) return undefined;
+  const code = String(countryCode).trim().toUpperCase();
+  return COUNTRY_LANGUAGE_MAP[code];
+}
+
+function computeLanguageSettings({ country, preferredLanguage } = {}) {
+  const available = [];
+  const addLanguage = (code) => {
+    if (!code && code !== 0) return;
+    const normalized = String(code).trim().toLowerCase();
+    if (!normalized) return;
+    if (!LANGUAGE_CODES.includes(normalized)) {
+      throw new Error(`Unsupported language code: ${code}`);
+    }
+    if (!available.includes(normalized)) {
+      available.push(normalized);
+    }
+    return normalized;
+  };
+
+  const result = {
+    country: undefined,
+    language: DEFAULT_LANGUAGE,
+    languages: [DEFAULT_LANGUAGE],
+  };
+
+  if (country) {
+    const normalizedCountry = String(country).trim().toUpperCase();
+    const config = COUNTRY_LANGUAGE_MAP[normalizedCountry];
+
+    if (!config) {
+      throw new Error(`Unsupported country code: ${country}`);
+    }
+
+    result.country = normalizedCountry;
+
+    for (const lang of config.languages) {
+      addLanguage(lang);
+    }
+
+    if (preferredLanguage) {
+      const normalizedLang = String(preferredLanguage).trim().toLowerCase();
+      if (!available.includes(normalizedLang)) {
+        throw new Error(
+          `Language ${preferredLanguage} is not available for country ${normalizedCountry}`
+        );
+      }
+      result.language = normalizedLang;
+    } else {
+      const fallback = config.default || config.languages[0] || DEFAULT_LANGUAGE;
+      const normalizedFallback = String(fallback).trim().toLowerCase();
+      if (!available.includes(normalizedFallback)) {
+        addLanguage(normalizedFallback);
+      }
+      result.language = normalizedFallback;
+    }
+  } else if (preferredLanguage) {
+    const normalizedLang = addLanguage(preferredLanguage);
+    result.language = normalizedLang || DEFAULT_LANGUAGE;
+  }
+
+  addLanguage(DEFAULT_LANGUAGE);
+
+  result.languages = available.length ? available : [DEFAULT_LANGUAGE];
+  if (!result.languages.includes(result.language)) {
+    result.languages.push(result.language);
+  }
+  if (result.languages[0] !== result.language) {
+    result.languages = [
+      result.language,
+      ...result.languages.filter((code) => code !== result.language),
+    ];
+  }
+
+  return result;
+}
+
+module.exports = {
+  LANGUAGE_CODES,
+  DEFAULT_LANGUAGE,
+  COUNTRY_LANGUAGE_MAP,
+  getCountryConfig,
+  computeLanguageSettings,
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,5 +1,10 @@
 // ./models/user.js
 const mongoose = require('mongoose');
+const {
+  LANGUAGE_CODES,
+  DEFAULT_LANGUAGE,
+  computeLanguageSettings,
+} = require('../lib/language');
 
 const userSchema = new mongoose.Schema({
   //user fields
@@ -27,9 +32,37 @@ const userSchema = new mongoose.Schema({
   googleId: { type: String, index: true },         // only for Google
   picture: { type: String },
 
+  country: { type: String, uppercase: true, trim: true },
+  language: { type: String, enum: LANGUAGE_CODES, default: DEFAULT_LANGUAGE },
+  languages: {
+    type: [String],
+    default: [DEFAULT_LANGUAGE],
+    validate: {
+      validator: (arr) => Array.isArray(arr) && arr.every((code) => LANGUAGE_CODES.includes(code)),
+      message: 'One or more provided languages are not supported.',
+    },
+  },
+
   roles: { type: [String], default: ['user'] },
   isActive: { type: Boolean, default: true },
   lastLoginAt: { type: Date },
 }, { timestamps: true });
+
+userSchema.pre('validate', function ensureLanguageDefaults(next) {
+  try {
+    const settings = computeLanguageSettings({
+      country: this.country,
+      preferredLanguage: this.language,
+    });
+
+    this.country = settings.country;
+    this.language = settings.language;
+    this.languages = settings.languages;
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
 
 module.exports = mongoose.model('User', userSchema);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -2,6 +2,7 @@ const express = require("express");
 const bcrypt = require("bcrypt");
 const { OAuth2Client } = require("google-auth-library");
 const User = require("../models/user");
+const { computeLanguageSettings } = require("../lib/language");
 const { setSessionCookie, readSession, clearSessionCookie } = require("../lib/session");
 
 const router = express.Router();
@@ -12,7 +13,17 @@ const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 // ────────────────────────────────
 router.post("/register", async (req, res) => {
   try {
-    const { email, username, password, fullName, dateOfBirth, gender, phoneNumber } = req.body;
+    const {
+      email,
+      username,
+      password,
+      fullName,
+      dateOfBirth,
+      gender,
+      phoneNumber,
+      country,
+      language,
+    } = req.body;
 
     if (!fullName || !password || (!email && !username)) {
       return res.status(400).json({
@@ -51,6 +62,21 @@ router.post("/register", async (req, res) => {
 
     if (emailKey) userData.email = emailKey;       // only set if not empty
     if (usernameKey) userData.username = usernameKey; // only set if not empty
+
+    if (country || language) {
+      try {
+        const settings = computeLanguageSettings({
+          country,
+          preferredLanguage: language,
+        });
+
+        if (settings.country) userData.country = settings.country;
+        userData.language = settings.language;
+        userData.languages = settings.languages;
+      } catch (langErr) {
+        return res.status(400).json({ message: langErr.message });
+      }
+    }
 
     const user = await User.create(userData);
 


### PR DESCRIPTION
## Summary
- add a shared language configuration module for supported countries and i18n codes
- extend the user model with country, preferred language, and available languages backed by validation
- update registration to derive and persist language settings from the submitted country and language

## Testing
- node -e "const { computeLanguageSettings } = require('./backend/lib/language'); console.log(computeLanguageSettings({ country: 'DE', preferredLanguage: 'de' }));"
- node -e "const { computeLanguageSettings } = require('./backend/lib/language'); console.log(computeLanguageSettings({ country: 'IL' }));"

------
https://chatgpt.com/codex/tasks/task_e_68f0d800b6048322b16cd1a4d1516b4a