### PR TITLE
Persist language preferences per user

### DIFF
--- a/backend/lib/language.js
+++ b/backend/lib/language.js
@@ -1,0 +1,94 @@
+const LANGUAGE_CODES = ["en", "de", "fi", "he"];
+const DEFAULT_LANGUAGE = "en";
+
+const COUNTRY_LANGUAGE_MAP = {
+  DE: { default: "de", languages: ["de", "en"] },
+  FI: { default: "fi", languages: ["fi", "en"] },
+  IL: { default: "he", languages: ["he", "en"] },
+};
+
+function getCountryConfig(countryCode) {
+  if (!countryCode) return undefined;
+  const code = String(countryCode).trim().toUpperCase();
+  return COUNTRY_LANGUAGE_MAP[code];
+}
+
+function computeLanguageSettings({ country, preferredLanguage } = {}) {
+  const available = [];
+  const addLanguage = (code) => {
+    if (!code && code !== 0) return;
+    const normalized = String(code).trim().toLowerCase();
+    if (!normalized) return;
+    if (!LANGUAGE_CODES.includes(normalized)) {
+      throw new Error(`Unsupported language code: ${code}`);
+    }
+    if (!available.includes(normalized)) {
+      available.push(normalized);
+    }
+    return normalized;
+  };
+
+  const result = {
+    country: undefined,
+    language: DEFAULT_LANGUAGE,
+    languages: [DEFAULT_LANGUAGE],
+  };
+
+  if (country) {
+    const normalizedCountry = String(country).trim().toUpperCase();
+    const config = COUNTRY_LANGUAGE_MAP[normalizedCountry];
+
+    if (!config) {
+      throw new Error(`Unsupported country code: ${country}`);
+    }
+
+    result.country = normalizedCountry;
+
+    for (const lang of config.languages) {
+      addLanguage(lang);
+    }
+
+    if (preferredLanguage) {
+      const normalizedLang = String(preferredLanguage).trim().toLowerCase();
+      if (!available.includes(normalizedLang)) {
+        throw new Error(
+          `Language ${preferredLanguage} is not available for country ${normalizedCountry}`
+        );
+      }
+      result.language = normalizedLang;
+    } else {
+      const fallback = config.default || config.languages[0] || DEFAULT_LANGUAGE;
+      const normalizedFallback = String(fallback).trim().toLowerCase();
+      if (!available.includes(normalizedFallback)) {
+        addLanguage(normalizedFallback);
+      }
+      result.language = normalizedFallback;
+    }
+  } else if (preferredLanguage) {
+    const normalizedLang = addLanguage(preferredLanguage);
+    result.language = normalizedLang || DEFAULT_LANGUAGE;
+  }
+
+  addLanguage(DEFAULT_LANGUAGE);
+
+  result.languages = available.length ? available : [DEFAULT_LANGUAGE];
+  if (!result.languages.includes(result.language)) {
+    result.languages.push(result.language);
+  }
+  if (result.languages[0] !== result.language) {
+    result.languages = [
+      result.language,
+      ...result.languages.filter((code) => code !== result.language),
+    ];
+  }
+
+  return result;
+}
+
+module.exports = {
+  LANGUAGE_CODES,
+  DEFAULT_LANGUAGE,
+  COUNTRY_LANGUAGE_MAP,
+  getCountryConfig,
+  computeLanguageSettings,
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,5 +1,10 @@
 // ./models/user.js
 const mongoose = require('mongoose');
+const {
+  LANGUAGE_CODES,
+  DEFAULT_LANGUAGE,
+  computeLanguageSettings,
+} = require('../lib/language');
 
 const userSchema = new mongoose.Schema({
   //user fields
@@ -27,9 +32,37 @@ const userSchema = new mongoose.Schema({
   googleId: { type: String, index: true },         // only for Google
   picture: { type: String },
 
+  country: { type: String, uppercase: true, trim: true },
+  language: { type: String, enum: LANGUAGE_CODES, default: DEFAULT_LANGUAGE },
+  languages: {
+    type: [String],
+    default: [DEFAULT_LANGUAGE],
+    validate: {
+      validator: (arr) => Array.isArray(arr) && arr.every((code) => LANGUAGE_CODES.includes(code)),
+      message: 'One or more provided languages are not supported.',
+    },
+  },
+
   roles: { type: [String], default: ['user'] },
   isActive: { type: Boolean, default: true },
   lastLoginAt: { type: Date },
 }, { timestamps: true });
+
+userSchema.pre('validate', function ensureLanguageDefaults(next) {
+  try {
+    const settings = computeLanguageSettings({
+      country: this.country,
+      preferredLanguage: this.language,
+    });
+
+    this.country = settings.country;
+    this.language = settings.language;
+    this.languages = settings.languages;
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
 
 module.exports = mongoose.model('User', userSchema);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -2,6 +2,7 @@ const express = require("express");
 const bcrypt = require("bcrypt");
 const { OAuth2Client } = require("google-auth-library");
 const User = require("../models/user");
+const { computeLanguageSettings } = require("../lib/language");
 const { setSessionCookie, readSession, clearSessionCookie } = require("../lib/session");
 
 const router = express.Router();
@@ -12,7 +13,17 @@ const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 // ────────────────────────────────
 router.post("/register", async (req, res) => {
   try {
-    const { email, username, password, fullName, dateOfBirth, gender, phoneNumber } = req.body;
+    const {
+      email,
+      username,
+      password,
+      fullName,
+      dateOfBirth,
+      gender,
+      phoneNumber,
+      country,
+      language,
+    } = req.body;
 
     if (!fullName || !password || (!email && !username)) {
       return res.status(400).json({
@@ -51,6 +62,21 @@ router.post("/register", async (req, res) => {
 
     if (emailKey) userData.email = emailKey;       // only set if not empty
     if (usernameKey) userData.username = usernameKey; // only set if not empty
+
+    if (country || language) {
+      try {
+        const settings = computeLanguageSettings({
+          country,
+          preferredLanguage: language,
+        });
+
+        if (settings.country) userData.country = settings.country;
+        userData.language = settings.language;
+        userData.languages = settings.languages;
+      } catch (langErr) {
+        return res.status(400).json({ message: langErr.message });
+      }
+    }
 
     const user = await User.create(userData);
 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -134,14 +134,16 @@ router.put("/:id", async (req, res) => {
       }
     }
 
-    const user = await User.findOneAndUpdate(
-      { id: req.params.id },
-      updates,
-      { new: true, runValidators: true }
-    ).select("-passwordHash");
-
+    const user = await User.findOne({ id: req.params.id });
     if (!user) return res.status(404).json({ message: "User not found" });
-    res.json(user);
+
+    Object.assign(user, updates);
+
+    const saved = await user.save();
+    const safe = saved.toObject();
+    delete safe.passwordHash;
+
+    res.json(safe);
   } catch (e) {
     res.status(400).json({ message: e.message });
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Login from "./components/Login";
 import Register from "./components/Register";
 import { AppContext } from "./shared/AppContext";
 import { API, fetchJsonAuth } from "./shared/config";
+import i18n from "./shared/i18n";
 
 export default function App() {
   const [user, setUser] = useState(null);
@@ -34,6 +35,14 @@ export default function App() {
       }
     })();
   }, []);
+
+  useEffect(() => {
+    const preferred = user?.language;
+    if (!preferred || i18n.language === preferred) return;
+
+    i18n.changeLanguage(preferred).catch(() => {});
+    localStorage.setItem("i18nextLng", preferred);
+  }, [user?.language]);
 
   const handleLoggedIn = async () => {
     try {

--- a/frontend/src/features/SettingsModal.jsx
+++ b/frontend/src/features/SettingsModal.jsx
@@ -1,5 +1,5 @@
 // CareBell/src/features/SettingsModal.jsx
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState, useContext, useMemo } from "react";
 import {
   FaVolumeMute,
   FaVolumeUp,
@@ -20,6 +20,33 @@ export default function SettingsModal({ onClose }) {
   const [diabetic, setDiabetic] = useState(user?.Diabetic || false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [saveStatus, setSaveStatus] = useState(null); // 'success' | 'error'
+  const [languageSaving, setLanguageSaving] = useState(false);
+  const [languageError, setLanguageError] = useState(null);
+
+  const LANGUAGE_LABELS = useMemo(
+    () => ({
+      en: "English",
+      he: "עברית",
+      de: "Deutsch",
+      fi: "Suomi",
+    }),
+    []
+  );
+
+  const availableLanguages = useMemo(() => {
+    if (user?.languages?.length) {
+      const seen = new Set();
+      return user.languages.filter((code) => {
+        if (!code) return false;
+        if (seen.has(code)) return false;
+        seen.add(code);
+        return true;
+      });
+    }
+    return Object.keys(LANGUAGE_LABELS);
+  }, [LANGUAGE_LABELS, user]);
+
+  const languageLabel = (code) => LANGUAGE_LABELS[code] || code;
 
   useEffect(() => {
     setSelectedAllergens(user?.Allergens || []);
@@ -33,9 +60,45 @@ export default function SettingsModal({ onClose }) {
   }, [scale]);
 
   // 2) Change language
-  const changeLanguage = (lng) => {
-    i18n.changeLanguage(lng);
-    localStorage.setItem("i18nextLng", lng);
+  const changeLanguage = async (lng) => {
+    if (!lng || lng === i18n.language) return;
+
+    setLanguageError(null);
+    const previous = i18n.language;
+    let shouldResetSpinner = false;
+
+    try {
+      await i18n.changeLanguage(lng);
+      localStorage.setItem("i18nextLng", lng);
+
+      if (!user?.id) return;
+
+      setLanguageSaving(true);
+      shouldResetSpinner = true;
+      const res = await fetch(`${API}/users/${user.id}`, {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ language: lng }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.message || "Failed to update language");
+      }
+
+      const updated = await res.json();
+      setUser(updated);
+    } catch (err) {
+      console.error("Failed to change language", err);
+      setLanguageError(err?.message || "Failed to update language");
+      await i18n.changeLanguage(previous).catch(() => {});
+      localStorage.setItem("i18nextLng", previous);
+    } finally {
+      if (shouldResetSpinner) {
+        setLanguageSaving(false);
+      }
+    }
   };
 
   const allergens = t("Meals.Legend.Allergens", { returnObjects: true });
@@ -174,12 +237,17 @@ export default function SettingsModal({ onClose }) {
                       value={i18n.language}
                       onChange={(e) => changeLanguage(e.target.value)}
                       className="border rounded px-2 py-1 border-teal-400 dark:bg-blue-900 dark:hover:bg-blue-800"
+                      disabled={languageSaving}
                     >
-                      <option value="en">English</option>
-                      <option value="he">עברית</option>
-                      <option value="de">Deutsch</option>
-                      <option value="fi">Suomi</option>
+                      {availableLanguages.map((code) => (
+                        <option key={code} value={code}>
+                          {languageLabel(code)}
+                        </option>
+                      ))}
                     </select>
+                    {languageError && (
+                      <p className="mt-2 text-sm text-red-600">{languageError}</p>
+                    )}
                   </div>
                 </div>
               </section>


### PR DESCRIPTION
## Summary
- ensure the app switches to a user's stored language whenever their profile loads
- limit the settings modal language picker to the languages saved on the profile and persist changes back to the server
- save user updates through mongoose so language validations and derived fields stay consistent

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68f0d800b6048322b16cd1a4d1516b4a