### PR TITLE
Restore food admin CRUD and localization

### DIFF
--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -151,8 +151,6 @@ app.use('/rooms',         roomsRoute);
 app.use('/tts',           ttsRoute);
 app.use("/admin/users", adminUsersRoute);
 app.use("/admin/foods", adminFoodsRoute);
-app.use("/admin/users", adminUsersRoute);
-app.use("/admin/foods", adminFoodsRoute);
 
 
 app.get('/', (_req, res) => {

--- a/backend/lib/allergenMap.js
+++ b/backend/lib/allergenMap.js
@@ -17,6 +17,15 @@ const FLAG_TO_ENTRY = Object.fromEntries(
   Object.entries(ENTRY_TO_FLAG).map(([entry, flag]) => [flag, entry])
 );
 
+function isTruthy(value) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    return /^(1|true|yes|on)$/i.test(value.trim());
+  }
+  return false;
+}
+
 // Derive boolean flags from allergen names (used by Meals/UI)
 function deriveFlagsFromAllergens(allergens = []) {
   const flags = { R:false,S:false,G:false,M:false,A:false,W:false,K:false,Y:false };
@@ -30,8 +39,13 @@ function deriveFlagsFromAllergens(allergens = []) {
 // Derive allergen list from boolean flags (used by Admin creation/update)
 function deriveAllergensFromFlags(flags = {}) {
   return Object.entries(FLAG_TO_ENTRY)
-    .filter(([flag]) => flags[`contains_${flag}`])
-    .map(([_, label]) => label);
+    .filter(([flag]) => {
+      const containsKey = `contains_${flag}`;
+      if (containsKey in flags) return isTruthy(flags[containsKey]);
+      if (flag in flags) return isTruthy(flags[flag]);
+      return false;
+    })
+    .map(([, label]) => label);
 }
 
 module.exports = {

--- a/backend/lib/language.js
+++ b/backend/lib/language.js
@@ -1,4 +1,5 @@
 const LANGUAGE_CODES = ["en", "de", "fi", "he"];
+const AVAILABLE_LANGUAGES = Object.freeze([...LANGUAGE_CODES]);
 const DEFAULT_LANGUAGE = "en";
 
 const COUNTRY_LANGUAGE_MAP = {
@@ -152,6 +153,7 @@ function normalizeUserLanguage(doc = {}) {
 }
 
 module.exports = {
+  AVAILABLE_LANGUAGES,
   LANGUAGE_CODES,
   DEFAULT_LANGUAGE,
   COUNTRY_LANGUAGE_MAP,

--- a/backend/routes/admin/foods.js
+++ b/backend/routes/admin/foods.js
@@ -142,7 +142,9 @@ function serializeFood(food) {
   }
 
   const imageId = obj.id ?? obj._id;
-  obj.imageURL = imageId ? `/foods/${imageId}/image` : null;
+  const stringifiedId = imageId != null ? imageId.toString() : null;
+  obj.imageURL = stringifiedId ? `/admin/foods/${stringifiedId}/image` : null;
+  obj.publicImageURL = stringifiedId ? `/foods/${stringifiedId}/image` : null;
 
   return obj;
 }

--- a/backend/routes/admin/foods.js
+++ b/backend/routes/admin/foods.js
@@ -1,197 +1,380 @@
-// backend/routes/admin/foods.js
 const express = require("express");
 const multer = require("multer");
+const mongoose = require("mongoose");
+
 const Food = require("../../models/food");
 const isAdmin = require("../../middleware/isAdmin");
 const { deriveAllergensFromFlags } = require("../../lib/allergenMap");
 const { AVAILABLE_LANGUAGES } = require("../../lib/language");
 
 const router = express.Router();
-const storage = multer.memoryStorage();
-const upload = multer({ storage });
+const upload = multer({ storage: multer.memoryStorage() });
 
-// ──────────────────────────────────────────────
-// PUBLIC IMAGE ACCESS (must come before isAdmin)
-// ──────────────────────────────────────────────
+const FLAG_KEYS = ["R", "S", "G", "M", "A", "W", "K", "Y"];
+
+router.use(isAdmin);
+
+function safeFoodQuery(idOrString) {
+  if (!idOrString) return {};
+  if (mongoose.Types.ObjectId.isValid(idOrString)) {
+    return {
+      $or: [
+        { _id: idOrString },
+        { id: Number(idOrString) || idOrString },
+      ],
+    };
+  }
+  const asNum = Number(idOrString);
+  if (!Number.isNaN(asNum)) return { id: asNum };
+  return { id: idOrString };
+}
+
+function normalizeText(value) {
+  if (value == null) return "";
+  return String(value).trim();
+}
+
+function normalizeBool(value) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    return /^(1|true|yes|on)$/i.test(value.trim());
+  }
+  return false;
+}
+
+function normalizeArray(value) {
+  if (value == null) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => normalizeText(entry))
+      .filter((entry) => entry.length > 0);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((entry) => normalizeText(entry))
+          .filter((entry) => entry.length > 0);
+      }
+    } catch (_) {}
+    return trimmed
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }
+  return [];
+}
+
+function collectContainsFlags(source = {}, { includeMissing = false } = {}) {
+  const result = {};
+  for (const key of FLAG_KEYS) {
+    const field = `contains_${key}`;
+    if (Object.prototype.hasOwnProperty.call(source, field)) {
+      result[field] = normalizeBool(source[field]);
+    } else if (includeMissing) {
+      result[field] = false;
+    }
+  }
+  return result;
+}
+
+function collectTranslations(source = {}) {
+  const translations = {};
+  for (const lang of AVAILABLE_LANGUAGES) {
+    const dishKey = `dish_${lang}`;
+    const descriptionKey = `description_${lang}`;
+    const categoryKey = `category_${lang}`;
+
+    const hasDish = Object.prototype.hasOwnProperty.call(source, dishKey);
+    const hasDescription = Object.prototype.hasOwnProperty.call(
+      source,
+      descriptionKey
+    );
+    const hasCategory = Object.prototype.hasOwnProperty.call(
+      source,
+      categoryKey
+    );
+
+    if (!hasDish && !hasDescription && !hasCategory) continue;
+
+    const dish = hasDish ? normalizeText(source[dishKey]) : "";
+    const description = hasDescription ? normalizeText(source[descriptionKey]) : "";
+    const category = hasCategory ? normalizeText(source[categoryKey]) : "";
+
+    if (hasDish) delete source[dishKey];
+    if (hasDescription) delete source[descriptionKey];
+    if (hasCategory) delete source[categoryKey];
+
+    translations[lang] = { dish, description, category };
+  }
+  return translations;
+}
+
+function mergeEnglishFallback(target, translations, body = {}) {
+  const english = translations.en;
+  if (!english) return;
+
+  if (!normalizeText(target.dish)) {
+    target.dish = english.dish || target.dish;
+  }
+  if (!normalizeText(target.description)) {
+    target.description = english.description || target.description;
+  }
+  if (!normalizeText(target.category)) {
+    const fallbackCategory = english.category || body.category;
+    if (normalizeText(fallbackCategory)) {
+      target.category = fallbackCategory;
+    }
+  }
+}
+
+function serializeFood(food) {
+  const obj = food?.toObject ? food.toObject({ virtuals: true }) : { ...food };
+
+  if (obj.image) delete obj.image;
+
+  if (obj.translations instanceof Map) {
+    obj.translations = Object.fromEntries(obj.translations);
+  }
+
+  const imageId = obj.id ?? obj._id;
+  obj.imageURL = imageId ? `/foods/${imageId}/image` : null;
+
+  return obj;
+}
+
+router.get("/", async (req, res) => {
+  try {
+    const { q } = req.query;
+    const filter = {};
+
+    if (q && q.toString().trim()) {
+      const escaped = q.toString().trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const rx = new RegExp(escaped, "i");
+      filter.$or = [
+        { dish: rx },
+        { barcode: rx },
+        { category: rx },
+        { description: rx },
+      ];
+    }
+
+    const foods = await Food.find(filter).sort({ createdAt: -1 });
+    res.json(foods.map(serializeFood));
+  } catch (err) {
+    console.error("Admin foods list failed:", err);
+    res.status(500).json({ message: "Failed to load foods" });
+  }
+});
+
 router.get("/:id/image", async (req, res) => {
   try {
-    const food = await Food.findById(req.params.id);
-    if (!food || !food.image?.data) {
+    const food = await Food.findOne(safeFoodQuery(req.params.id)).lean();
+    if (!food || !food.image || !food.image.data) {
       return res.status(404).send("Image not found");
     }
     res.contentType(food.image.contentType || "image/png");
     res.send(food.image.data);
   } catch (err) {
-    console.error("GET /foods/:id/image failed:", err);
+    console.error("Admin food image failed:", err);
     res.status(500).send("Error retrieving image");
   }
 });
 
-// ──────────────────────────────────────────────
-// ADMIN-ONLY ROUTES BELOW
-// ──────────────────────────────────────────────
-router.use(isAdmin);
-
-/* Helper: extract translations from form data */
-function extractTranslations(body) {
-  const translations = {};
-  for (const lang of AVAILABLE_LANGUAGES) {
-    const dish = body[`dish_${lang}`];
-    const description = body[`description_${lang}`];
-    const category = body[`category_${lang}`];          // ✅ new
-    if (dish || description || category) {
-      translations[lang] = {
-        dish: dish || "",
-        description: description || "",
-        category: category || "",                       // ✅ new
-      };
-    }
-  }
-  return translations;
-}
-
-/* Helper: sanitize and enrich food object */
-function foodToJSON(food) {
-  const obj = food.toObject({ virtuals: true });
-  if (obj.image?.data) delete obj.image;
-  obj.imageURL = `/foods/${obj._id}/image`;
-  return obj;
-}
-
-// ──────────────────────────────────────────────
-// GET /admin/foods?q=search
-// ──────────────────────────────────────────────
-router.get("/", async (req, res) => {
-  try {
-    const q = req.query.q?.trim();
-    const filter = q
-      ? {
-          $or: [
-            { dish: { $regex: q, $options: "i" } },
-            { category: { $regex: q, $options: "i" } },
-            { barcode: { $regex: q, $options: "i" } },
-          ],
-        }
-      : {};
-    const foods = await Food.find(filter).sort({ dish: 1 });
-    res.json(foods.map(foodToJSON));
-  } catch (err) {
-    console.error("GET /admin/foods failed:", err);
-    res.status(500).json({ message: "Failed to fetch foods" });
-  }
-});
-
-// ──────────────────────────────────────────────
-// POST /admin/foods  (multipart/form-data)
-// ──────────────────────────────────────────────
 router.post("/", upload.single("image"), async (req, res) => {
   try {
-    const { barcode, date, category, diabeticFriendly, ...rest } = req.body;
+    const body = { ...req.body };
+    const translations = collectTranslations(body);
+    const containsFlags = collectContainsFlags(body, { includeMissing: true });
 
-    // Extract contains flags
-    const containsFlags = {};
-    for (const c of ["R", "S", "G", "M", "A", "W", "K", "Y"]) {
-      containsFlags[`contains_${c}`] =
-        rest[`contains_${c}`] === "true" || rest[`contains_${c}`] === "on";
+    const manualAllergens = normalizeArray(body.allergens);
+    const additives = normalizeArray(body.additives);
+    const pictograms = normalizeArray(body.pictograms);
+
+    const diabeticFriendly = normalizeBool(body.diabeticFriendly);
+    const barcode = normalizeText(body.barcode);
+    const date = normalizeText(body.date);
+    const baseFields = {
+      dish: normalizeText(body.dish),
+      description: normalizeText(body.description),
+      category: normalizeText(body.category),
+    };
+    mergeEnglishFallback(baseFields, translations, body);
+
+    if (!barcode) {
+      return res.status(400).json({ message: "Barcode is required" });
+    }
+    if (!date) {
+      return res.status(400).json({ message: "Date is required" });
+    }
+    if (!baseFields.dish) {
+      return res.status(400).json({ message: "Dish name is required" });
     }
 
-    // Auto-increment id
-    const lastFood = await Food.findOne().sort({ id: -1 }).lean();
-    const nextId = lastFood ? lastFood.id + 1 : 1;
+    let numericId;
+    if (body.id != null && body.id !== "") {
+      numericId = Number(body.id);
+      if (!Number.isFinite(numericId)) {
+        return res.status(400).json({ message: "Invalid id" });
+      }
+    } else {
+      const last = await Food.findOne().sort({ id: -1 }).lean();
+      numericId = (last?.id || 0) + 1;
+    }
 
-    // Derived fields
     const derivedAllergens = deriveAllergensFromFlags(containsFlags);
-    const translations = extractTranslations(req.body);
+    const allergenSet = new Set([...manualAllergens, ...derivedAllergens]);
 
-    const newFood = new Food({
+    const doc = new Food({
       barcode,
-      id: nextId,
+      id: numericId,
       date,
-      category,
-      diabeticFriendly:
-        diabeticFriendly === "true" || diabeticFriendly === "on",
-      allergens: derivedAllergens,
+      category: baseFields.category,
+      dish: baseFields.dish,
+      description: baseFields.description,
+      diabeticFriendly,
+      additives,
+      pictograms,
       translations,
       ...containsFlags,
+      allergens: Array.from(allergenSet),
     });
 
-    // Attach image
     if (req.file) {
-      newFood.image = {
+      doc.image = {
         data: req.file.buffer,
-        contentType: req.file.mimetype,
+        contentType: req.file.mimetype || "image/png",
       };
     }
 
-    await newFood.save();
-    res.json(foodToJSON(newFood));
+    await doc.save();
+    res.status(201).json(serializeFood(doc));
   } catch (err) {
-    console.error("POST /admin/foods failed:", err);
+    console.error("Food creation failed:", err);
+    if (err.code === 11000) {
+      return res
+        .status(409)
+        .json({ message: "A food with this barcode or id already exists" });
+    }
     res.status(500).json({ message: "Failed to create food" });
   }
 });
 
-// ──────────────────────────────────────────────
-// PUT /admin/foods/:id
-// ──────────────────────────────────────────────
-router.put("/:id", async (req, res) => {
+router.put("/:id", upload.single("image"), async (req, res) => {
   try {
-    const id = req.params.id;
-    const body = req.body;
+    const food = await Food.findOne(safeFoodQuery(req.params.id));
+    if (!food) return res.status(404).json({ message: "Food not found" });
 
-    const containsFlags = {};
-    for (const c of ["R", "S", "G", "M", "A", "W", "K", "Y"]) {
-      containsFlags[`contains_${c}`] =
-        body[`contains_${c}`] === "true" ||
-        body[`contains_${c}`] === "on" ||
-        body[`contains_${c}`] === true;
+    const body = { ...req.body };
+    const translations = collectTranslations(body);
+    const containsFlags = collectContainsFlags(body);
+
+    if (body.barcode != null) food.barcode = normalizeText(body.barcode);
+    if (body.date != null) food.date = normalizeText(body.date);
+    if (body.category != null) food.category = normalizeText(body.category);
+    if (body.dish != null) food.dish = normalizeText(body.dish);
+    if (body.description != null)
+      food.description = normalizeText(body.description);
+
+    if (body.diabeticFriendly != null) {
+      food.diabeticFriendly = normalizeBool(body.diabeticFriendly);
     }
 
-    const derivedAllergens = deriveAllergensFromFlags(containsFlags);
-    const translations = extractTranslations(body);
+    if (body.additives !== undefined) {
+      food.additives = normalizeArray(body.additives);
+    }
+    if (body.pictograms !== undefined) {
+      food.pictograms = normalizeArray(body.pictograms);
+    }
 
-    const updated = await Food.findByIdAndUpdate(
-      id,
-      { ...body, ...containsFlags, allergens: derivedAllergens, translations },
-      { new: true }
-    );
+    if (Object.keys(translations).length) {
+      const existing = food.translations instanceof Map
+        ? Object.fromEntries(food.translations)
+        : food.translations || {};
+      food.translations = { ...existing, ...translations };
+      mergeEnglishFallback(food, translations, body);
+    }
 
-    if (!updated) return res.status(404).json({ message: "Not found" });
-    res.json(foodToJSON(updated));
+    if (Object.keys(containsFlags).length) {
+      for (const [key, value] of Object.entries(containsFlags)) {
+        food[key] = value;
+      }
+    }
+
+    let manualAllergens;
+    if (body.allergens !== undefined) {
+      manualAllergens = normalizeArray(body.allergens);
+      food.allergens = manualAllergens;
+    }
+
+    if (req.file) {
+      food.image = {
+        data: req.file.buffer,
+        contentType: req.file.mimetype || "image/png",
+      };
+    }
+
+    const flagSnapshot = FLAG_KEYS.reduce((acc, key) => {
+      acc[`contains_${key}`] = food[`contains_${key}`];
+      return acc;
+    }, {});
+    const derivedAllergens = deriveAllergensFromFlags(flagSnapshot);
+
+    if (derivedAllergens.length || manualAllergens) {
+      const union = new Set([
+        ...(manualAllergens ?? food.allergens ?? []),
+        ...derivedAllergens,
+      ]);
+      food.allergens = Array.from(union);
+    } else if (!Array.isArray(food.allergens)) {
+      food.allergens = [];
+    }
+
+    await food.save();
+    res.json(serializeFood(food));
   } catch (err) {
-    console.error("PUT /admin/foods/:id failed:", err);
+    console.error("Food update error:", err);
+    if (err.code === 11000) {
+      return res
+        .status(409)
+        .json({ message: "A food with this barcode or id already exists" });
+    }
     res.status(500).json({ message: "Failed to update food" });
   }
 });
 
-// ──────────────────────────────────────────────
-// DELETE /admin/foods/:id
-// ──────────────────────────────────────────────
 router.delete("/:id", async (req, res) => {
   try {
-    const deleted = await Food.findByIdAndDelete(req.params.id);
-    if (!deleted) return res.status(404).json({ message: "Not found" });
-    res.json({ message: "Deleted successfully" });
+    const deleted = await Food.findOneAndDelete(safeFoodQuery(req.params.id));
+    if (!deleted) return res.status(404).json({ message: "Food not found" });
+    res.json({ success: true, message: "Food deleted", deleted: serializeFood(deleted) });
   } catch (err) {
-    console.error("DELETE /admin/foods/:id failed:", err);
+    console.error("Food delete error:", err);
     res.status(500).json({ message: "Failed to delete food" });
   }
 });
 
-// ──────────────────────────────────────────────
-// BULK DELETE
-// ──────────────────────────────────────────────
 router.post("/bulk-delete", async (req, res) => {
   try {
-    const ids = req.body.ids || [];
-    if (!Array.isArray(ids) || !ids.length)
-      return res.status(400).json({ message: "No IDs provided" });
+    const { ids } = req.body || {};
+    if (!Array.isArray(ids) || !ids.length) {
+      return res.status(400).json({ message: "Provide ids: []" });
+    }
 
-    const result = await Food.deleteMany({ _id: { $in: ids } });
-    res.json({ deletedCount: result.deletedCount });
+    const or = ids.map((value) => safeFoodQuery(value)).filter((query) => Object.keys(query).length);
+    if (!or.length) {
+      return res.json({ success: true, deletedCount: 0 });
+    }
+
+    const result = await Food.deleteMany({ $or: or });
+    res.json({ success: true, deletedCount: result.deletedCount || 0 });
   } catch (err) {
-    console.error("Bulk delete failed:", err);
-    res.status(500).json({ message: "Failed bulk delete" });
+    console.error("Food bulk delete error:", err);
+    res.status(500).json({ message: "Failed to delete foods" });
   }
 });
 

--- a/backend/routes/admin/foods.js
+++ b/backend/routes/admin/foods.js
@@ -12,6 +12,41 @@ const upload = multer({ storage: multer.memoryStorage() });
 
 const FLAG_KEYS = ["R", "S", "G", "M", "A", "W", "K", "Y"];
 
+function ensureBuffer(value) {
+  if (!value) return null;
+  if (Buffer.isBuffer(value)) return value;
+  if (value.buffer) return Buffer.from(value.buffer);
+  if (value.data) return ensureBuffer(value.data);
+  try {
+    return Buffer.from(value);
+  } catch (_err) {
+    return null;
+  }
+}
+
+router.get("/:id/image", isAdmin, async (req, res) => {
+  try {
+    const food = await Food.findOne(safeFoodQuery(req.params.id)).select(
+      "image id"
+    );
+    if (!food || !food.image || !food.image.data) {
+      return res.status(404).send("Image not found");
+    }
+
+    const buffer = ensureBuffer(food.image.data);
+    if (!buffer) {
+      return res.status(500).send("Image data unavailable");
+    }
+
+    res.setHeader("Content-Type", food.image.contentType || "image/png");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(buffer);
+  } catch (err) {
+    console.error("Admin food image failed:", err);
+    res.status(500).send("Error retrieving image");
+  }
+});
+
 router.use(isAdmin);
 
 function safeFoodQuery(idOrString) {
@@ -170,20 +205,6 @@ router.get("/", async (req, res) => {
   } catch (err) {
     console.error("Admin foods list failed:", err);
     res.status(500).json({ message: "Failed to load foods" });
-  }
-});
-
-router.get("/:id/image", async (req, res) => {
-  try {
-    const food = await Food.findOne(safeFoodQuery(req.params.id)).lean();
-    if (!food || !food.image || !food.image.data) {
-      return res.status(404).send("Image not found");
-    }
-    res.contentType(food.image.contentType || "image/png");
-    res.send(food.image.data);
-  } catch (err) {
-    console.error("Admin food image failed:", err);
-    res.status(500).send("Error retrieving image");
   }
 });
 

--- a/backend/routes/foods.js
+++ b/backend/routes/foods.js
@@ -64,7 +64,8 @@ function localizeFood(food, lang = "en", includeFull = false) {
   if (f.image && f.image.data) delete f.image;
 
   const imageId = f.id ?? f._id;
-  f.imageURL = imageId ? `/foods/${imageId}/image` : null;
+  const stringifiedId = imageId != null ? imageId.toString() : null;
+  f.imageURL = stringifiedId ? `/foods/${stringifiedId}/image` : null;
   return f;
 }
 

--- a/backend/routes/foods.js
+++ b/backend/routes/foods.js
@@ -108,17 +108,36 @@ router.get("/:barcode", async (req, res) => {
   }
 });
 
+function ensureBuffer(value) {
+  if (!value) return null;
+  if (Buffer.isBuffer(value)) return value;
+  if (value.buffer) return Buffer.from(value.buffer);
+  if (value.data) return ensureBuffer(value.data);
+  try {
+    return Buffer.from(value);
+  } catch (_err) {
+    return null;
+  }
+}
+
 /* ─────────────────────────────────────────────
    GET /foods/:id/image  → binary blob
 ────────────────────────────────────────────── */
 router.get("/:id/image", async (req, res) => {
   try {
-    const food = await Food.findOne(safeFoodQuery(req.params.id)).lean();
+    const food = await Food.findOne(safeFoodQuery(req.params.id)).select(
+      "image id"
+    );
     if (!food || !food.image || !food.image.data) {
       return res.status(404).send("Image not found");
     }
-    res.contentType(food.image.contentType || "image/png");
-    res.send(food.image.data);
+    const buffer = ensureBuffer(food.image.data);
+    if (!buffer) {
+      return res.status(500).send("Image data unavailable");
+    }
+    res.setHeader("Content-Type", food.image.contentType || "image/png");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(buffer);
   } catch (e) {
     console.error("GET /foods/:id/image failed:", e);
     res.status(500).send("Error retrieving image");

--- a/backend/routes/foods.js
+++ b/backend/routes/foods.js
@@ -20,9 +20,32 @@ function safeFoodQuery(idOrString) {
 /* ─────────────────────────────────────────────
    Helper to localize a food doc
 ────────────────────────────────────────────── */
+function toPlainTranslations(value) {
+  if (!value) return undefined;
+
+  const entries = value instanceof Map ? [...value.entries()] : Object.entries(value);
+  if (!entries.length) return undefined;
+
+  const result = {};
+  for (const [lang, raw] of entries) {
+    if (!lang) continue;
+    const plain =
+      raw && typeof raw === "object" && typeof raw.toObject === "function"
+        ? raw.toObject()
+        : { ...(raw || {}) };
+    result[lang] = {
+      dish: plain.dish || "",
+      description: plain.description || "",
+      category: plain.category || "",
+    };
+  }
+
+  return result;
+}
+
 function localizeFood(food, lang = "en", includeFull = false) {
   const f = food.toObject ? food.toObject() : { ...food };
-  const tr = f.translations || {};
+  const tr = toPlainTranslations(f.translations) || {};
 
   const normalizedLang = AVAILABLE_LANGUAGES.includes(lang) ? lang : "en";
   const t = tr[normalizedLang] || tr.en || {};
@@ -30,12 +53,18 @@ function localizeFood(food, lang = "en", includeFull = false) {
   // flatten localized values for easy access
   f.dish = t.dish || f.dish;
   f.description = t.description || f.description;
+  f.category = t.category || f.category;
 
-  if (!includeFull) delete f.translations;
-  if (f.image && f.image.data) delete f.image; // avoid blobs
+  if (!includeFull) {
+    delete f.translations;
+  } else {
+    f.translations = tr;
+  }
 
-  // add public image URL if applicable
-  if (f._id || f.id) f.imageURL = `/foods/${f._id || f.id}/image`;
+  if (f.image && f.image.data) delete f.image;
+
+  const imageId = f.id ?? f._id;
+  f.imageURL = imageId ? `/foods/${imageId}/image` : null;
   return f;
 }
 

--- a/frontend/src/features/Meals.jsx
+++ b/frontend/src/features/Meals.jsx
@@ -49,7 +49,7 @@ export default function Meals() {
     setBarcode(code);
     setLoading(true);
     try {
-      const res = await fetch(`${API}/${code}`);
+      const res = await fetch(`${API}/foods/${code}`);
       if (!res.ok) {
         if (res.status === 404) throw new Error("404");
         throw new Error(`Server ${res.status}`);
@@ -135,20 +135,30 @@ export default function Meals() {
 
   const createFoodDescription = (item) => {
     const dish = getLocalizedField(item, "dish");
-    const description = getLocalizedField(item, "description");
-    const diabeticText = item.diabeticFriendly
-      ? t("Meals.diabeticFriendlyYes")
-      : t("Meals.diabeticFriendlyNo");
+    const description = getLocalizedField(item, "description") || t("Meals.noDescription");
+    const diabeticText = `${t("Meals.diabeticFriendlyLabel")} ${
+      item.diabeticFriendly
+        ? t("Meals.diabeticFriendlyYes")
+        : t("Meals.diabeticFriendlyNo")
+    }`;
 
-    // build text for TTS — now uses localized allergen names
-    let desc = `${dish}. <break time='300ms'/> ${description || t("Meals.noDescription")}. <break time='300ms'/> `;
-    desc += `${diabeticText}. `;
+    const sentences = [];
+    const pushSentence = (value) => {
+      const text = (value || "").toString().trim();
+      if (!text) return;
+      sentences.push(text.replace(/[.?!]+$/u, ""));
+    };
+
+    pushSentence(dish);
+    pushSentence(description);
+    pushSentence(diabeticText);
 
     const allergens = trAllergens(item.allergens || []).join(", ");
     if (allergens) {
-      desc += `<break time='300ms'/> ${t("Meals.allergensList")} ${allergens}. `;
+      pushSentence(`${t("Meals.LegendHeadings.Allergens")}: ${allergens}`);
     }
-    return desc;
+
+    return sentences.length ? `${sentences.join(". ")}.` : "";
   };
 
   const backToList = () => {
@@ -227,9 +237,9 @@ export default function Meals() {
       {/* SINGLE MEAL VIEW */}
       {meal && (
         <div className="bg-green-50 p-8 mt-8 rounded-lg border-l-8 border-green-500 shadow-lg dark:border-yellow-400 dark:bg-slate-700">
-          {meal.id && (
+          {meal.imageURL && (
             <img
-              src={`${API}/foods/${meal.id}/image`}
+              src={`${API}${meal.imageURL}`}
               alt={getLocalizedField(meal, "dish")}
               className="w-full max-w-md mx-auto rounded-lg shadow-md mb-6"
             />

--- a/frontend/src/features/Meals.jsx
+++ b/frontend/src/features/Meals.jsx
@@ -1,5 +1,5 @@
 // frontend/src/features/Meals.jsx
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useCallback, useRef } from "react";
 import BarcodeScannerComponent from "react-qr-barcode-scanner";
 import { API } from "../shared/config";
 import { useTranslation } from "react-i18next";
@@ -11,66 +11,110 @@ export default function Meals() {
   const { user } = useContext(AppContext);
   const userAllergens = user?.Allergens || [];
 
-  const [activeTab, setActiveTab] = useState("scanner");
   const [allMeals, setAllMeals] = useState([]);
   const [scanning, setScanning] = useState(false);
   const [manualCode, setManualCode] = useState("");
-  const [barcode, setBarcode] = useState(null);
   const [meal, setMeal] = useState(null);
+  const [activeBarcode, setActiveBarcode] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [speaking, setSpeaking] = useState(false);
-  const [audioObj, setAudioObj] = useState(null);
-
-  /* ---------- effects ---------- */
-  useEffect(() => {
-    fetchAllMeals();
-  }, []);
-  useEffect(() => () => { if (audioObj) audioObj.pause(); }, [audioObj]);
+  const audioRef = useRef(null);
+  const activeBarcodeRef = useRef("");
 
   /* ---------- fetch helpers ---------- */
-  const fetchAllMeals = async () => {
+  const fetchAllMeals = useCallback(async () => {
     try {
       setLoading(true);
-      const res = await fetch(`${API}/foods`);
+      const lang = i18n.language.split("-")[0];
+      const res = await fetch(`${API}/foods?lang=${lang}`);
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       const data = await res.json();
       if (!Array.isArray(data)) throw new Error("Invalid data format");
       setAllMeals(data);
+      const currentBarcode = activeBarcodeRef.current;
+      if (currentBarcode) {
+        const updated = data.find((m) => m.barcode === currentBarcode);
+        if (updated) setMeal(updated);
+      }
     } catch (err) {
       setError(`Could not load meals: ${err.message}`);
       setAllMeals([]);
     } finally {
       setLoading(false);
     }
-  };
+  }, [i18n.language]);
 
-  const fetchByCode = async (code) => {
-    setBarcode(code);
-    setLoading(true);
-    try {
-      const res = await fetch(`${API}/foods/${code}`);
-      if (!res.ok) {
-        if (res.status === 404) throw new Error("404");
-        throw new Error(`Server ${res.status}`);
+  /* ---------- effects ---------- */
+  useEffect(() => {
+    fetchAllMeals();
+  }, [fetchAllMeals]);
+  useEffect(() => {
+    activeBarcodeRef.current = activeBarcode;
+  }, [activeBarcode]);
+  useEffect(
+    () => () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.currentTime = 0;
+        audioRef.current = null;
       }
-      const data = await res.json();
-      setMeal(data);
-      setTimeout(() => speakText(createFoodDescription(data)), 1000);
-    } catch {
-      const fallback = allMeals.find((m) => m.barcode === code);
-      if (fallback) {
-        setMeal(fallback);
-        setTimeout(() => speakText(createFoodDescription(fallback)), 1000);
-      } else {
-        setError(t("Meals.notFoundWithCode", { code }));
-        setMeal(null);
-        speakText(t("Meals.notFoundSpoken"));
+    },
+    []
+  );
+  const fetchByCode = useCallback(
+    async (code, { speak = true, showNotFoundError = true } = {}) => {
+      const trimmed = (code || "").trim();
+      if (!trimmed) return;
+      setActiveBarcode(trimmed);
+      setLoading(true);
+      setError("");
+      try {
+        const lang = i18n.language.split("-")[0];
+        const res = await fetch(`${API}/foods/${trimmed}?lang=${lang}`);
+        if (!res.ok) {
+          const err = new Error(res.status === 404 ? "NOT_FOUND" : "HTTP_ERROR");
+          err.status = res.status;
+          throw err;
+        }
+        const data = await res.json();
+        setMeal(data);
+        if (speak) {
+          setTimeout(() => speakText(createFoodDescription(data)), 600);
+        }
+      } catch (err) {
+        console.warn("Meal lookup failed", err);
+        const fallback = allMeals.find((m) => m.barcode === trimmed);
+        if (fallback) {
+          setMeal(fallback);
+          if (speak) {
+            setTimeout(() => speakText(createFoodDescription(fallback)), 600);
+          }
+        } else if (showNotFoundError) {
+          setMeal(null);
+          const message = t("Meals.notFoundWithCode", { code: trimmed });
+          setError(message);
+          if (speak) {
+            setTimeout(() => speakText(t("Meals.notFoundSpoken")), 300);
+          }
+        }
+      } finally {
+        setLoading(false);
       }
-    } finally {
-      setLoading(false);
-    }
-  };
+    },
+    [
+      allMeals,
+      createFoodDescription,
+      i18n.language,
+      speakText,
+      t,
+    ]
+  );
+
+  useEffect(() => {
+    if (!activeBarcode) return;
+    fetchByCode(activeBarcode, { speak: false, showNotFoundError: false });
+  }, [activeBarcode, fetchByCode, i18n.language]);
 
   /* ---------- barcode handlers ---------- */
   const handleDetected = (_, result) => {
@@ -90,82 +134,100 @@ export default function Meals() {
     setScanning((s) => !s);
   };
 
-  const speakText = async (text) => {
-    stopSpeaking();
-    if (!text) return;
-    try {
-      const lang = i18n.language.split("-")[0];
-      const audio = await playTts(text, lang);
-      setAudioObj(audio);
-      setSpeaking(true);
-      audio.onended = () => {
-        setSpeaking(false);
-        setAudioObj(null);
-      };
-    } catch (err) {
-      console.error("TTS error:", err);
-    }
-  };
-
-  const stopSpeaking = () => {
-    if (audioObj) {
-      audioObj.pause();
-      audioObj.currentTime = 0;
-      setAudioObj(null);
+  const stopSpeaking = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+      audioRef.current = null;
     }
     setSpeaking(false);
-  };
+  }, []);
+
+  const speakText = useCallback(
+    async (text) => {
+      stopSpeaking();
+      if (!text) return;
+      try {
+        const lang = i18n.language.split("-")[0];
+        const audio = await playTts(text, lang);
+        audioRef.current = audio;
+        setSpeaking(true);
+        audio.onended = () => {
+          if (audioRef.current === audio) {
+            audioRef.current = null;
+            setSpeaking(false);
+          }
+        };
+      } catch (err) {
+        console.error("TTS error:", err);
+      }
+    },
+    [i18n.language, stopSpeaking]
+  );
 
   /* ---------- helpers ---------- */
-  const getLocalizedField = (meal, field) => {
-    const lang = i18n.language.split("-")[0];
-    return (
-      meal.translations?.[lang]?.[field] ||
-      meal.translations?.en?.[field] ||
-      meal[field] ||
-      ""
-    );
-  };
+  const getLocalizedField = useCallback(
+    (meal, field) => {
+      const direct = meal?.[field];
+      if (direct && String(direct).trim().length) return direct;
 
-  const trAllergens = (list) =>
-    (list || []).map((a) => {
-      const key = a.toLowerCase();
-      return t(`Meals.Legend.Allergens.${key}`, key);
-    });
+      const lang = i18n.language.split("-")[0];
+      return (
+        meal?.translations?.[lang]?.[field] ||
+        meal?.translations?.en?.[field] ||
+        ""
+      );
+    },
+    [i18n.language]
+  );
 
-  const createFoodDescription = (item) => {
-    const dish = getLocalizedField(item, "dish");
-    const description = getLocalizedField(item, "description") || t("Meals.noDescription");
-    const diabeticText = `${t("Meals.diabeticFriendlyLabel")} ${
-      item.diabeticFriendly
-        ? t("Meals.diabeticFriendlyYes")
-        : t("Meals.diabeticFriendlyNo")
-    }`;
+  const trAllergens = useCallback(
+    (list) =>
+      (list || []).map((a) => {
+        const key = a.toLowerCase();
+        return t(`Meals.Legend.Allergens.${key}`, key);
+      }),
+    [t]
+  );
 
-    const sentences = [];
-    const pushSentence = (value) => {
-      const text = (value || "").toString().trim();
-      if (!text) return;
-      sentences.push(text.replace(/[.?!]+$/u, ""));
-    };
+  const createFoodDescription = useCallback(
+    (item) => {
+      const dish = getLocalizedField(item, "dish");
+      const description =
+        getLocalizedField(item, "description") || t("Meals.noDescription");
+      const diabeticText = `${t("Meals.diabeticFriendlyLabel")} ${
+        item.diabeticFriendly
+          ? t("Meals.diabeticFriendlyYes")
+          : t("Meals.diabeticFriendlyNo")
+      }`;
 
-    pushSentence(dish);
-    pushSentence(description);
-    pushSentence(diabeticText);
+      const sentences = [];
+      const pushSentence = (value) => {
+        const text = (value || "").toString().trim();
+        if (!text) return;
+        sentences.push(text.replace(/[.?!]+$/u, ""));
+      };
 
-    const allergens = trAllergens(item.allergens || []).join(", ");
-    if (allergens) {
-      pushSentence(`${t("Meals.LegendHeadings.Allergens")}: ${allergens}`);
-    }
+      pushSentence(dish);
+      pushSentence(description);
+      pushSentence(diabeticText);
 
-    return sentences.length ? `${sentences.join(". ")}.` : "";
-  };
+      const allergens = trAllergens(item.allergens || []).join(", ");
+      if (allergens) {
+        pushSentence(`${t("Meals.LegendHeadings.Allergens")}: ${allergens}`);
+      }
+
+      return sentences.length ? `${sentences.join(". ")}.` : "";
+    },
+    [getLocalizedField, trAllergens, t]
+  );
 
   const backToList = () => {
     setMeal(null);
     setManualCode("");
     setError("");
-    setActiveTab("scanner");
+    setActiveBarcode("");
+    stopSpeaking();
   };
 
   /* ---------- render ---------- */
@@ -174,6 +236,15 @@ export default function Meals() {
       <h1 className="text-4xl font-bold mb-8 text-center text-blue-800">
         {t("Meals.FoodInfo")}
       </h1>
+
+      {loading && (
+        <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+          {t("Meals.loadingLabel")}
+        </p>
+      )}
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400 mb-4">{error}</p>
+      )}
 
       {/* SCANNER / MANUAL */}
       {!meal && (

--- a/frontend/src/features/News.jsx
+++ b/frontend/src/features/News.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { API, NEWS_REGIONS } from "../shared/config";
 import { useTranslation } from "react-i18next";
-import { playTts, playSmartTts } from "../shared/tts";
+import { playTts } from "../shared/tts";
 
 export default function News() {
   const { t, i18n } = useTranslation();

--- a/frontend/src/features/admin/AddFoodModal.jsx
+++ b/frontend/src/features/admin/AddFoodModal.jsx
@@ -30,8 +30,28 @@ export default function AddFoodModal({ onClose }) {
       );
       if (file) fd.append("image", file);
 
-      // append translations generically
-      for (const [lang, { dish, description, category }] of Object.entries(translations)) {
+      const translationPayload = Object.fromEntries(
+        Object.entries(translations).map(([lang, values]) => [
+          lang,
+          {
+            dish: values?.dish?.trim() || "",
+            description: values?.description?.trim() || "",
+            category: values?.category?.trim() || "",
+          },
+        ])
+      );
+
+      if (!translationPayload.en) {
+        translationPayload.en = { dish: "", description: "", category: "" };
+      }
+
+      if (!translationPayload.en.category && form.category) {
+        translationPayload.en.category = form.category.trim();
+      }
+
+      for (const [lang, { dish, description, category }] of Object.entries(
+        translationPayload
+      )) {
         if (dish) fd.append(`dish_${lang}`, dish);
         if (description) fd.append(`description_${lang}`, description);
         if (category) fd.append(`category_${lang}`, category);
@@ -90,6 +110,12 @@ export default function AddFoodModal({ onClose }) {
             onChange={(e) => updateTranslation(activeLang, "dish", e.target.value)}
             className="w-full px-3 py-2 rounded border dark:bg-gray-700"
             required={activeLang === "en"}
+          />
+          <input
+            placeholder={`Category (${LANG_LABELS[activeLang]})`}
+            value={translations[activeLang]?.category || ""}
+            onChange={(e) => updateTranslation(activeLang, "category", e.target.value)}
+            className="w-full px-3 py-2 rounded border dark:bg-gray-700"
           />
           <textarea
             placeholder={`Description (${LANG_LABELS[activeLang]})`}

--- a/frontend/src/features/admin/AddFoodModal.jsx
+++ b/frontend/src/features/admin/AddFoodModal.jsx
@@ -11,7 +11,9 @@ export default function AddFoodModal({ onClose }) {
     diabeticFriendly: false,
   });
   const [translations, setTranslations] = useState(
-    Object.fromEntries(AVAILABLE_LANGUAGES.map((l) => [l, { dish: "", description: "" }]))
+    Object.fromEntries(
+      AVAILABLE_LANGUAGES.map((l) => [l, { dish: "", description: "", category: "" }])
+    )
   );
   const [activeLang, setActiveLang] = useState("en");
   const [file, setFile] = useState(null);
@@ -29,9 +31,10 @@ export default function AddFoodModal({ onClose }) {
       if (file) fd.append("image", file);
 
       // append translations generically
-      for (const [lang, { dish, description }] of Object.entries(translations)) {
+      for (const [lang, { dish, description, category }] of Object.entries(translations)) {
         if (dish) fd.append(`dish_${lang}`, dish);
         if (description) fd.append(`description_${lang}`, description);
+        if (category) fd.append(`category_${lang}`, category);
       }
 
       const res = await fetch(`${API}/admin/foods`, {

--- a/frontend/src/features/admin/AddFoodModal.jsx
+++ b/frontend/src/features/admin/AddFoodModal.jsx
@@ -1,9 +1,16 @@
 // frontend/src/features/admin/AddFoodModal.jsx
-import React, { useState } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { API } from "../../shared/config";
 import { AVAILABLE_LANGUAGES, LANG_LABELS } from "../../shared/constants";
+import { useTranslation } from "react-i18next";
 
 export default function AddFoodModal({ onClose }) {
+  const { t, i18n } = useTranslation();
+  const defaultLanguage = useMemo(
+    () => (i18n.language || "en").split("-")[0] || "en",
+    [i18n.language]
+  );
+  const languageLabel = (lang) => LANG_LABELS[lang] || lang.toUpperCase();
   const [form, setForm] = useState({
     barcode: "",
     date: new Date().toISOString().slice(0, 10),
@@ -15,10 +22,14 @@ export default function AddFoodModal({ onClose }) {
       AVAILABLE_LANGUAGES.map((l) => [l, { dish: "", description: "", category: "" }])
     )
   );
-  const [activeLang, setActiveLang] = useState("en");
+  const [activeLang, setActiveLang] = useState(defaultLanguage);
   const [file, setFile] = useState(null);
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState(null);
+
+  useEffect(() => {
+    setActiveLang(defaultLanguage);
+  }, [defaultLanguage]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -65,10 +76,10 @@ export default function AddFoodModal({ onClose }) {
       const data = await res.json();
       if (!res.ok) throw new Error(data.message || "Failed to add food");
 
-      setMsg("✅ Added successfully");
+      setMsg(t("Admin.Common.messages.added"));
       setTimeout(onClose, 1000);
     } catch (err) {
-      setMsg(`❌ ${err.message}`);
+      setMsg(t("Admin.Common.messages.error", { message: err.message }));
     } finally {
       setLoading(false);
     }
@@ -83,7 +94,9 @@ export default function AddFoodModal({ onClose }) {
   return (
     <div className="fixed inset-0 bg-black/50 flex justify-center items-center z-50">
       <div className="bg-white dark:bg-gray-900 p-6 rounded-lg w-[90%] max-w-2xl shadow-lg">
-        <h2 className="text-2xl font-bold mb-4">Add New Food</h2>
+        <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">
+          {t("Admin.Foods.modals.addTitle")}
+        </h2>
 
         {/* Language Tabs */}
         <div className="flex gap-2 mb-4 border-b border-gray-300 dark:border-gray-700">
@@ -97,7 +110,7 @@ export default function AddFoodModal({ onClose }) {
                   : "bg-gray-200 dark:bg-gray-700 dark:text-gray-200"
               }`}
             >
-              {LANG_LABELS[lang] || lang.toUpperCase()}
+              {languageLabel(lang)}
             </button>
           ))}
         </div>
@@ -105,20 +118,26 @@ export default function AddFoodModal({ onClose }) {
         {/* Active Language Form */}
         <div className="space-y-3 mb-4">
           <input
-            placeholder={`Dish (${LANG_LABELS[activeLang]})`}
+            placeholder={t("Admin.Foods.forms.dish", {
+              language: languageLabel(activeLang),
+            })}
             value={translations[activeLang]?.dish || ""}
             onChange={(e) => updateTranslation(activeLang, "dish", e.target.value)}
             className="w-full px-3 py-2 rounded border dark:bg-gray-700"
             required={activeLang === "en"}
           />
           <input
-            placeholder={`Category (${LANG_LABELS[activeLang]})`}
+            placeholder={t("Admin.Foods.forms.category", {
+              language: languageLabel(activeLang),
+            })}
             value={translations[activeLang]?.category || ""}
             onChange={(e) => updateTranslation(activeLang, "category", e.target.value)}
             className="w-full px-3 py-2 rounded border dark:bg-gray-700"
           />
           <textarea
-            placeholder={`Description (${LANG_LABELS[activeLang]})`}
+            placeholder={t("Admin.Foods.forms.description", {
+              language: languageLabel(activeLang),
+            })}
             value={translations[activeLang]?.description || ""}
             onChange={(e) => updateTranslation(activeLang, "description", e.target.value)}
             className="w-full px-3 py-2 rounded border dark:bg-gray-700"
@@ -129,7 +148,7 @@ export default function AddFoodModal({ onClose }) {
         {/* Shared Fields */}
         <form onSubmit={handleSubmit} className="space-y-3">
           <input
-            placeholder="Barcode"
+            placeholder={t("Admin.Foods.modals.barcode")}
             value={form.barcode}
             onChange={(e) => setForm({ ...form, barcode: e.target.value })}
             className="w-full px-3 py-2 rounded border dark:bg-gray-700"
@@ -143,7 +162,7 @@ export default function AddFoodModal({ onClose }) {
             required
           />
           <input
-            placeholder="Category"
+            placeholder={t("Admin.Foods.modals.baseCategory")}
             value={form.category}
             onChange={(e) => setForm({ ...form, category: e.target.value })}
             className="w-full px-3 py-2 rounded border dark:bg-gray-700"
@@ -158,11 +177,13 @@ export default function AddFoodModal({ onClose }) {
                 setForm({ ...form, diabeticFriendly: e.target.checked })
               }
             />
-            Diabetic Friendly
+            {t("Admin.Foods.modals.diabeticFriendly")}
           </label>
 
           <div>
-            <p className="font-semibold mb-1">Contains Flags</p>
+            <p className="font-semibold mb-1">
+              {t("Admin.Foods.modals.containsFlags")}
+            </p>
             <div className="grid grid-cols-4 gap-2 text-sm">
               {["R", "S", "G", "M", "A", "W", "K", "Y"].map((c) => (
                 <label key={c} className="flex items-center gap-1">
@@ -194,14 +215,16 @@ export default function AddFoodModal({ onClose }) {
               onClick={onClose}
               className="px-4 py-2 rounded bg-gray-500 text-white"
             >
-              Cancel
+              {t("Admin.Common.buttons.cancel")}
             </button>
             <button
               type="submit"
               disabled={loading}
               className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-500 text-white"
             >
-              {loading ? "Saving..." : "Save"}
+              {loading
+                ? t("Admin.Common.labels.saving")
+                : t("Admin.Common.buttons.save")}
             </button>
           </div>
         </form>

--- a/frontend/src/features/admin/AddUserModal.jsx
+++ b/frontend/src/features/admin/AddUserModal.jsx
@@ -2,8 +2,10 @@
 import React, { useState } from "react";
 import { API } from "../../shared/config";
 import { COUNTRIES, AVAILABLE_LANGUAGES, LANG_LABELS } from "../../shared/constants";
+import { useTranslation } from "react-i18next";
 
 export default function AddUserModal({ open, onClose, onAdded }) {
+  const { t } = useTranslation();
   const [form, setForm] = useState({
     fullName: "",
     username: "",
@@ -23,6 +25,8 @@ export default function AddUserModal({ open, onClose, onAdded }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  const languageLabel = (code) => LANG_LABELS[code] || code.toUpperCase();
+
   if (!open) return null;
 
   const handleChange = (e) => {
@@ -35,11 +39,11 @@ export default function AddUserModal({ open, onClose, onAdded }) {
     setError(null);
 
     if (form.password && form.password !== form.confirmPassword) {
-      setError("Passwords do not match");
+      setError(t("Admin.Users.add.errors.passwordMismatch"));
       return;
     }
     if (!form.fullName.trim()) {
-      setError("Full name is required");
+      setError(t("Admin.Users.add.errors.fullNameRequired"));
       return;
     }
 
@@ -94,7 +98,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
         language: "",
       });
     } catch (err) {
-      setError(err.message);
+      setError(t("Admin.Users.add.errors.generic", { message: err.message }));
     } finally {
       setLoading(false);
     }
@@ -104,39 +108,39 @@ export default function AddUserModal({ open, onClose, onAdded }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="w-[92%] max-w-xl bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-6">
         <h3 className="text-2xl font-bold mb-4 text-blue-900 dark:text-blue-200">
-          Add New User
+          {t("Admin.Users.modals.addTitle")}
         </h3>
 
         <form onSubmit={handleSubmit} className="space-y-3">
           {/* Login credentials */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <input
-              name="username"
-              placeholder="Username"
+              <input
+                name="username"
+                placeholder={t("Admin.Users.fields.username")}
               value={form.username}
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
-            <input
-              name="email"
-              placeholder="Email"
-              type="email"
+              <input
+                name="email"
+                placeholder={t("Admin.Users.fields.email")}
+                type="email"
               value={form.email}
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
-            <input
-              name="password"
-              type="password"
-              placeholder="Password"
+              <input
+                name="password"
+                type="password"
+                placeholder={t("Admin.Users.fields.password")}
               value={form.password}
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
-            <input
-              name="confirmPassword"
-              type="password"
-              placeholder="Confirm Password"
+              <input
+                name="confirmPassword"
+                type="password"
+                placeholder={t("Admin.Users.fields.confirmPassword")}
               value={form.confirmPassword}
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
@@ -145,24 +149,24 @@ export default function AddUserModal({ open, onClose, onAdded }) {
 
           {/* Basic info */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <input
-              name="fullName"
-              placeholder="Full name *"
+              <input
+                name="fullName"
+                placeholder={t("Admin.Users.fields.fullName")}
               value={form.fullName}
               onChange={handleChange}
               required
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
-            <input
-              name="phoneNumber"
-              placeholder="Phone number"
+              <input
+                name="phoneNumber"
+                placeholder={t("Admin.Users.fields.phone")}
               value={form.phoneNumber}
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
-            <input
-              name="address"
-              placeholder="Address"
+              <input
+                name="address"
+                placeholder={t("Admin.Users.fields.address")}
               value={form.address}
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100 md:col-span-2"
@@ -174,21 +178,23 @@ export default function AddUserModal({ open, onClose, onAdded }) {
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
-            <select
-              name="gender"
-              value={form.gender}
-              onChange={handleChange}
-              className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
-            >
-              <option value="male">Male</option>
-              <option value="female">Female</option>
-              <option value="other">Other</option>
-            </select>
+              <select
+                name="gender"
+                value={form.gender}
+                onChange={handleChange}
+                className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
+              >
+                <option value="male">{t("Admin.Users.gender.male")}</option>
+                <option value="female">{t("Admin.Users.gender.female")}</option>
+                <option value="other">{t("Admin.Users.gender.other")}</option>
+              </select>
           </div>
 
           {/* Health flags */}
           <div>
-            <div className="text-sm font-semibold mb-1 text-gray-800 dark:text-gray-200">Health Flags</div>
+            <div className="text-sm font-semibold mb-1 text-gray-800 dark:text-gray-200">
+              {t("Admin.Users.labels.healthFlags")}
+            </div>
             <div className="grid grid-cols-4 gap-2">
               {["R","S","G","M","A","W","K","Y"].map((key) => (
                 <label key={key} className="flex items-center gap-2">
@@ -206,9 +212,9 @@ export default function AddUserModal({ open, onClose, onAdded }) {
 
           {/* Allergens & Diabetic */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <input
-              name="AllergensCSV"
-              placeholder="Allergens (comma separated)"
+              <input
+                name="AllergensCSV"
+                placeholder={t("Admin.Users.fields.allergens")}
               value={form.AllergensCSV}
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
@@ -220,7 +226,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
                 checked={form.Diabetic}
                 onChange={handleChange}
               />
-              <span className="text-sm">Diabetic</span>
+                <span className="text-sm">{t("Admin.Users.labels.diabetic")}</span>
             </label>
           </div>
 
@@ -232,7 +238,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             >
-              <option value="">Country (UI only)</option>
+                <option value="">{t("Admin.Users.fields.countryPlaceholder")}</option>
               {COUNTRIES.map((c) => (
                 <option key={c.code} value={c.code}>
                   {c.flag} {c.name}
@@ -246,10 +252,10 @@ export default function AddUserModal({ open, onClose, onAdded }) {
               onChange={handleChange}
               className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             >
-              <option value="">Language (UI only)</option>
-              {(COUNTRIES.find(c => c.code === form.country)?.languages || AVAILABLE_LANGUAGES).map((lang) => (
-                <option key={lang} value={lang}>{LANG_LABELS[lang]}</option>
-              ))}
+                <option value="">{t("Admin.Users.fields.languagePlaceholder")}</option>
+                {(COUNTRIES.find(c => c.code === form.country)?.languages || AVAILABLE_LANGUAGES).map((lang) => (
+                  <option key={lang} value={lang}>{languageLabel(lang)}</option>
+                ))}
             </select>
           </div>
 
@@ -263,7 +269,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
               onClick={onClose}
               className="px-4 py-2 rounded bg-gray-300 dark:bg-gray-700 hover:bg-gray-400 dark:hover:bg-gray-600"
             >
-              Cancel
+              {t("Admin.Common.buttons.cancel")}
             </button>
             <button
               type="submit"
@@ -272,7 +278,9 @@ export default function AddUserModal({ open, onClose, onAdded }) {
                 loading ? "bg-gray-500 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-500"
               }`}
             >
-              {loading ? "Saving…" : "Add User"}
+              {loading
+                ? t("Admin.Common.labels.saving")
+                : t("Admin.Users.buttons.add")}
             </button>
           </div>
         </form>

--- a/frontend/src/features/admin/FoodManager.jsx
+++ b/frontend/src/features/admin/FoodManager.jsx
@@ -1,22 +1,42 @@
 // frontend/src/features/admin/FoodManager.jsx
-import React, { useEffect, useState } from "react";
+import React, {
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+} from "react";
 import { API } from "../../shared/config";
 import NotificationModal from "../../components/NotificationModal";
 import AddFoodModal from "./AddFoodModal";
 import { AVAILABLE_LANGUAGES, LANG_LABELS } from "../../shared/constants";
+import { useTranslation } from "react-i18next";
 
 export default function FoodManager() {
+  const { t, i18n } = useTranslation();
   const toFoodKey = (food) => {
     const raw = food?.id ?? food?._id;
     return raw != null ? raw.toString() : "";
   };
 
+  const activeLanguageCode = useMemo(
+    () => (i18n.language || "en").split("-")[0] || "en",
+    [i18n.language]
+  );
+
   const [foods, setFoods] = useState([]);
   const [editingId, setEditingId] = useState(null);
   const [editForm, setEditForm] = useState({});
   const [translations, setTranslations] = useState({});
-  const [activeLang, setActiveLang] = useState("en");
-  const [viewLang, setViewLang] = useState("en");
+  const [activeLang, setActiveLang] = useState(activeLanguageCode);
+  const [viewLang, setViewLang] = useState(() => {
+    if (typeof window !== "undefined") {
+      const saved = window.localStorage.getItem("adminViewLang");
+      if (saved && AVAILABLE_LANGUAGES.includes(saved)) {
+        return saved;
+      }
+    }
+    return activeLanguageCode;
+  });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [saveMsg, setSaveMsg] = useState(null);
@@ -24,10 +44,12 @@ export default function FoodManager() {
   const [query, setQuery] = useState("");
   const [addOpen, setAddOpen] = useState(false);
 
+  const languageLabel = (lang) => LANG_LABELS[lang] || lang.toUpperCase();
+
   /* ───────────────────────────────
      Fetch all foods
   ─────────────────────────────── */
-  async function fetchFoods() {
+  const fetchFoods = useCallback(async () => {
     setLoading(true);
     try {
       const res = await fetch(
@@ -39,25 +61,26 @@ export default function FoodManager() {
       setFoods(Array.isArray(data) ? data : []);
     } catch (err) {
       console.error(err);
-      setError(err.message);
+      setError(t("Admin.Foods.messages.loadError", { message: err.message }));
       setFoods([]);
     } finally {
       setLoading(false);
     }
-  }
+  }, [query, t]);
 
   useEffect(() => {
     fetchFoods();
-  }, []);
+  }, [fetchFoods]);
 
-  // Persist preferred preview language
   useEffect(() => {
-    const saved = localStorage.getItem("adminViewLang");
-    if (saved && AVAILABLE_LANGUAGES.includes(saved)) setViewLang(saved);
-  }, []);
-  useEffect(() => {
-    localStorage.setItem("adminViewLang", viewLang);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("adminViewLang", viewLang);
+    }
   }, [viewLang]);
+
+  useEffect(() => {
+    setActiveLang(activeLanguageCode);
+  }, [activeLanguageCode]);
 
   /* ───────────────────────────────
      Editing setup
@@ -90,7 +113,7 @@ export default function FoodManager() {
         ])
       ),
     });
-    setActiveLang("en");
+    setActiveLang(activeLanguageCode);
   };
 
   const cancelEdit = () => {
@@ -133,11 +156,11 @@ export default function FoodManager() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.message || "Failed to save");
-      setSaveMsg("✅ Saved");
+      setSaveMsg(t("Admin.Common.messages.saved"));
       await fetchFoods();
       cancelEdit();
     } catch (err) {
-      setError(err.message);
+      setError(t("Admin.Foods.messages.saveError", { message: err.message }));
     } finally {
       setLoading(false);
     }
@@ -148,7 +171,12 @@ export default function FoodManager() {
   ─────────────────────────────── */
   async function deleteSelected() {
     if (selected.size === 0) return;
-    if (!confirm(`Delete ${selected.size} food item(s)?`)) return;
+    if (
+      !window.confirm(
+        t("Admin.Foods.messages.confirmDeleteMany", { count: selected.size })
+      )
+    )
+      return;
     try {
       const res = await fetch(`${API}/admin/foods/bulk-delete`, {
         method: "POST",
@@ -158,11 +186,13 @@ export default function FoodManager() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.message || "Failed to delete");
-      setSaveMsg(`🗑️ Deleted ${data.deletedCount} item(s)`);
+      setSaveMsg(
+        t("Admin.Common.messages.deleted", { count: data.deletedCount || 0 })
+      );
       setSelected(new Set());
       fetchFoods();
     } catch (err) {
-      setError(err.message);
+      setError(t("Admin.Foods.messages.deleteError", { message: err.message }));
     }
   }
 
@@ -173,7 +203,8 @@ export default function FoodManager() {
   };
 
   const renderAllergenTags = (list = []) => {
-    if (!list.length) return <span className="text-gray-400">-</span>;
+    if (!list.length)
+      return <span className="text-gray-400">{t("Admin.Common.labels.none")}</span>;
     return (
       <div className="flex flex-wrap gap-1 justify-center">
         {list.map((a, i) => (
@@ -193,27 +224,30 @@ export default function FoodManager() {
   ─────────────────────────────── */
   return (
     <div className="space-y-4">
+      <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+        {t("Admin.Foods.title")}
+      </h2>
       {/* Top controls */}
       <div className="flex justify-between items-center flex-wrap gap-2">
         <div className="flex gap-2">
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search dish, category or barcode..."
+            placeholder={t("Admin.Foods.searchPlaceholder")}
             className="px-3 py-2 rounded border dark:bg-gray-700 dark:border-gray-600"
           />
           <button
             onClick={fetchFoods}
             className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-500 text-white"
           >
-            Search
+            {t("Admin.Common.buttons.search")}
           </button>
         </div>
 
         {/* 🌍 Language preview selector */}
         <div className="flex items-center gap-2">
           <label className="font-semibold text-sm text-gray-700 dark:text-gray-300">
-            View Language:
+            {t("Admin.Common.labels.viewLanguage")}
           </label>
           <select
             value={viewLang}
@@ -222,7 +256,7 @@ export default function FoodManager() {
           >
             {AVAILABLE_LANGUAGES.map((lang) => (
               <option key={lang} value={lang}>
-                {LANG_LABELS[lang] || lang.toUpperCase()}
+                {languageLabel(lang)}
               </option>
             ))}
           </select>
@@ -233,20 +267,20 @@ export default function FoodManager() {
             onClick={() => setAddOpen(true)}
             className="px-4 py-2 rounded bg-green-600 hover:bg-green-500 text-white"
           >
-            ➕ Add Food
+            ➕ {t("Admin.Foods.buttons.addFood")}
           </button>
           {selected.size > 0 && (
             <button
               onClick={deleteSelected}
               className="px-4 py-2 rounded bg-red-600 hover:bg-red-500 text-white"
             >
-              🗑️ Delete Selected ({selected.size})
+              🗑️ {t("Admin.Common.buttons.deleteSelected", { count: selected.size })}
             </button>
           )}
         </div>
       </div>
 
-      {loading && <p>Loading...</p>}
+      {loading && <p>{t("Admin.Common.labels.loading")}</p>}
       {error && <p className="text-red-500">{error}</p>}
       {saveMsg && (
         <NotificationModal message={saveMsg} onClose={() => setSaveMsg(null)} />
@@ -258,21 +292,22 @@ export default function FoodManager() {
           <thead className="bg-gray-200 dark:bg-gray-700">
             <tr>
               <th className="p-2"></th>
-              <th className="p-2">Image</th>
-              <th className="p-2">Barcode</th>
-              <th className="p-2">Dish</th>
-              <th className="p-2">Category</th>
-              <th className="p-2">Description</th>
-              <th className="p-2">Allergens</th>
-              <th className="p-2">Diabetic</th>
-              <th className="p-2">Contains Flags</th>
-              <th className="p-2">Actions</th>
+              <th className="p-2">{t("Admin.Foods.columns.image")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.barcode")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.dish")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.category")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.description")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.allergens")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.diabetic")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.contains")}</th>
+              <th className="p-2">{t("Admin.Foods.columns.actions")}</th>
             </tr>
           </thead>
           <tbody>
             {foods.map((f) => {
               const rowKey = toFoodKey(f);
-              const imagePath = f.imageURL || f.publicImageURL;
+              const primaryPath = f.imageURL || null;
+              const fallbackPath = f.publicImageURL || null;
               return (
                 <tr
                   key={rowKey || f._id}
@@ -286,14 +321,20 @@ export default function FoodManager() {
                     />
                   </td>
                   <td className="p-2 text-center">
-                    {imagePath ? (
-                      <img
-                        src={`${API}${imagePath}`}
-                        alt="food"
-                        className="w-12 h-12 object-cover rounded mx-auto"
+                    {primaryPath || fallbackPath ? (
+                      <FoodImageCell
+                        primary={primaryPath}
+                        fallback={fallbackPath}
+                        alt={
+                          f.translations?.[viewLang]?.dish ||
+                          f.dish ||
+                          t("Admin.Foods.columns.image")
+                        }
                       />
                     ) : (
-                      <span className="text-gray-400">no image</span>
+                      <span className="text-gray-400">
+                        {t("Admin.Common.labels.noImage")}
+                      </span>
                     )}
                   </td>
                   <td className="p-2">{f.barcode}</td>
@@ -313,13 +354,15 @@ export default function FoodManager() {
                                 : "bg-gray-200 dark:bg-gray-700 dark:text-gray-200"
                             }`}
                           >
-                            {LANG_LABELS[lang]}
+                            {languageLabel(lang)}
                           </button>
                         ))}
                       </div>
                       <div className="space-y-2">
                         <input
-                          placeholder={`Dish (${LANG_LABELS[activeLang]})`}
+                          placeholder={t("Admin.Foods.forms.dish", {
+                            language: languageLabel(activeLang),
+                          })}
                           value={translations[activeLang]?.dish || ""}
                           onChange={(e) =>
                             updateTranslation(activeLang, "dish", e.target.value)
@@ -329,7 +372,9 @@ export default function FoodManager() {
 
                         {/* ✅ new: Category input */}
                         <input
-                          placeholder={`Category (${LANG_LABELS[activeLang]})`}
+                          placeholder={t("Admin.Foods.forms.category", {
+                            language: languageLabel(activeLang),
+                          })}
                           value={translations[activeLang]?.category || ""}
                           onChange={(e) =>
                             updateTranslation(activeLang, "category", e.target.value)
@@ -338,7 +383,9 @@ export default function FoodManager() {
                         />
 
                         <textarea
-                          placeholder={`Description (${LANG_LABELS[activeLang]})`}
+                          placeholder={t("Admin.Foods.forms.description", {
+                            language: languageLabel(activeLang),
+                          })}
                           value={translations[activeLang]?.description || ""}
                           onChange={(e) =>
                             updateTranslation(
@@ -388,13 +435,13 @@ export default function FoodManager() {
                         onClick={() => saveEdit(rowKey)}
                         className="px-2 py-1 bg-green-600 text-white rounded mr-1"
                       >
-                        Save
+                        {t("Admin.Common.buttons.save")}
                       </button>
                       <button
                         onClick={cancelEdit}
                         className="px-2 py-1 bg-gray-500 text-white rounded"
                       >
-                        Cancel
+                        {t("Admin.Common.buttons.cancel")}
                       </button>
                     </td>
                   </>
@@ -449,21 +496,36 @@ export default function FoodManager() {
                         onClick={() => startEdit(f)}
                         className="px-2 py-1 bg-blue-600 text-white rounded mr-1"
                       >
-                        Edit
+                        {t("Admin.Common.buttons.edit")}
                       </button>
                       <button
                         onClick={async () => {
-                          if (confirm("Delete this food?")) {
-                            await fetch(`${API}/admin/foods/${rowKey}`, {
-                              method: "DELETE",
-                              credentials: "include",
-                            });
-                            fetchFoods();
+                          if (
+                            window.confirm(
+                              t("Admin.Foods.messages.confirmDeleteOne")
+                            )
+                          ) {
+                            try {
+                              const res = await fetch(`${API}/admin/foods/${rowKey}`, {
+                                method: "DELETE",
+                                credentials: "include",
+                              });
+                              const data = await res.json().catch(() => ({}));
+                              if (!res.ok)
+                                throw new Error(data.message || `HTTP ${res.status}`);
+                              fetchFoods();
+                            } catch (err) {
+                              setError(
+                                t("Admin.Foods.messages.deleteError", {
+                                  message: err.message,
+                                })
+                              );
+                            }
                           }
                         }}
                         className="px-2 py-1 bg-red-600 text-white rounded"
                       >
-                        Delete
+                        {t("Admin.Common.buttons.delete")}
                       </button>
                     </td>
                   </>
@@ -486,3 +548,85 @@ export default function FoodManager() {
     </div>
   );
 }
+
+const FoodImageCell = ({ primary, fallback, alt }) => {
+  const { t } = useTranslation();
+  const [src, setSrc] = useState(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl = null;
+    const controller = new AbortController();
+
+    async function fetchImage() {
+      const uniquePaths = Array.from(
+        new Set([primary, fallback].filter(Boolean))
+      );
+      if (!uniquePaths.length) {
+        setSrc(null);
+        setError(true);
+        return;
+      }
+
+      for (const path of uniquePaths) {
+        try {
+          const absolute = path.startsWith("http") ? path : `${API}${path}`;
+          const response = await fetch(absolute, {
+            credentials: "include",
+            signal: controller.signal,
+          });
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          const blob = await response.blob();
+          if (cancelled) return;
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+          objectUrl = URL.createObjectURL(blob);
+          setSrc(objectUrl);
+          setError(false);
+          return;
+        } catch (err) {
+          if (cancelled) return;
+          console.warn("Food image fetch failed", err);
+        }
+      }
+
+      if (!cancelled) {
+        setSrc(null);
+        setError(true);
+      }
+    }
+
+    setSrc(null);
+    setError(false);
+    fetchImage();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [primary, fallback]);
+
+  if (error) {
+    return (
+      <span className="text-gray-400 text-sm">
+        {t("Admin.Common.labels.imageUnavailable")}
+      </span>
+    );
+  }
+
+  if (!src) {
+    return (
+      <span className="text-gray-400 text-sm">
+        {t("Admin.Common.labels.loading")}
+      </span>
+    );
+  }
+
+  return (
+    <img src={src} alt={alt} className="w-12 h-12 object-cover rounded mx-auto" />
+  );
+};
+

--- a/frontend/src/features/admin/FoodManager.jsx
+++ b/frontend/src/features/admin/FoodManager.jsx
@@ -6,6 +6,11 @@ import AddFoodModal from "./AddFoodModal";
 import { AVAILABLE_LANGUAGES, LANG_LABELS } from "../../shared/constants";
 
 export default function FoodManager() {
+  const toFoodKey = (food) => {
+    const raw = food?.id ?? food?._id;
+    return raw != null ? raw.toString() : "";
+  };
+
   const [foods, setFoods] = useState([]);
   const [editingId, setEditingId] = useState(null);
   const [editForm, setEditForm] = useState({});
@@ -58,7 +63,8 @@ export default function FoodManager() {
      Editing setup
   ─────────────────────────────── */
   const startEdit = (food) => {
-    setEditingId(food._id);
+    const key = toFoodKey(food);
+    setEditingId(key);
     const t = food.translations || {};
     setTranslations(
       Object.fromEntries(
@@ -264,33 +270,36 @@ export default function FoodManager() {
             </tr>
           </thead>
           <tbody>
-            {foods.map((f) => (
-              <tr
-                key={f._id}
-                className="border-t border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
-              >
-                <td className="p-2">
-                  <input
-                    type="checkbox"
-                    checked={selected.has(f._id)}
-                    onChange={() => toggleSelect(f._id)}
-                  />
-                </td>
-                <td className="p-2 text-center">
-                  {f.imageURL ? (
-                    <img
-                      src={`${API}${f.imageURL}`}
-                      alt="food"
-                      className="w-12 h-12 object-cover rounded mx-auto"
+            {foods.map((f) => {
+              const rowKey = toFoodKey(f);
+              const imagePath = f.imageURL || f.publicImageURL;
+              return (
+                <tr
+                  key={rowKey || f._id}
+                  className="border-t border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  <td className="p-2">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(rowKey)}
+                      onChange={() => toggleSelect(rowKey)}
                     />
-                  ) : (
-                    <span className="text-gray-400">no image</span>
-                  )}
-                </td>
-                <td className="p-2">{f.barcode}</td>
+                  </td>
+                  <td className="p-2 text-center">
+                    {imagePath ? (
+                      <img
+                        src={`${API}${imagePath}`}
+                        alt="food"
+                        className="w-12 h-12 object-cover rounded mx-auto"
+                      />
+                    ) : (
+                      <span className="text-gray-400">no image</span>
+                    )}
+                  </td>
+                  <td className="p-2">{f.barcode}</td>
 
-                {editingId === f._id ? (
-                  <>
+                  {editingId === rowKey ? (
+                    <>
                     {/* 🈯 Language Tabs */}
                     <td colSpan={3} className="p-2 align-top">
                       <div className="mb-2 flex gap-2 border-b border-gray-300 dark:border-gray-600">
@@ -376,7 +385,7 @@ export default function FoodManager() {
                     </td>
                     <td className="p-2 text-center">
                       <button
-                        onClick={() => saveEdit(f._id)}
+                        onClick={() => saveEdit(rowKey)}
                         className="px-2 py-1 bg-green-600 text-white rounded mr-1"
                       >
                         Save
@@ -445,7 +454,7 @@ export default function FoodManager() {
                       <button
                         onClick={async () => {
                           if (confirm("Delete this food?")) {
-                            await fetch(`${API}/admin/foods/${f._id}`, {
+                            await fetch(`${API}/admin/foods/${rowKey}`, {
                               method: "DELETE",
                               credentials: "include",
                             });
@@ -460,7 +469,8 @@ export default function FoodManager() {
                   </>
                 )}
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/frontend/src/features/admin/ResetPasswordModal.jsx
+++ b/frontend/src/features/admin/ResetPasswordModal.jsx
@@ -1,8 +1,10 @@
 // frontend/src/features/admin/ResetPasswordModal.jsx
 import React, { useState } from "react";
 import { API } from "../../shared/config";
+import { useTranslation } from "react-i18next";
 
 export default function ResetPasswordModal({ open, onClose, user }) {
+  const { t } = useTranslation();
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [loading, setLoading] = useState(false);
@@ -18,7 +20,7 @@ export default function ResetPasswordModal({ open, onClose, user }) {
     setSuccess(null);
 
     if (!password || password !== confirm) {
-      setError("Passwords do not match");
+      setError(t("Admin.Users.reset.errors.passwordMismatch"));
       return;
     }
 
@@ -33,7 +35,7 @@ export default function ResetPasswordModal({ open, onClose, user }) {
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data?.message || `Failed (${res.status})`);
 
-      setSuccess("Password reset successfully ✅");
+      setSuccess(t("Admin.Users.reset.success"));
       setPassword("");
       setConfirm("");
       setTimeout(() => {
@@ -41,7 +43,7 @@ export default function ResetPasswordModal({ open, onClose, user }) {
         setSuccess(null);
       }, 1500);
     } catch (err) {
-      setError(err.message);
+      setError(t("Admin.Users.reset.errors.generic", { message: err.message }));
     } finally {
       setLoading(false);
     }
@@ -51,20 +53,20 @@ export default function ResetPasswordModal({ open, onClose, user }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="w-[90%] max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-6">
         <h3 className="text-xl font-semibold mb-3 text-blue-900 dark:text-blue-200">
-          Reset Password for {user.fullName}
+          {t("Admin.Users.reset.title", { name: user.fullName })}
         </h3>
 
         <form onSubmit={handleSubmit} className="space-y-3">
           <input
             type="password"
-            placeholder="New password"
+            placeholder={t("Admin.Users.reset.fields.newPassword")}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
           />
           <input
             type="password"
-            placeholder="Confirm new password"
+            placeholder={t("Admin.Users.reset.fields.confirmPassword")}
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
             className="w-full rounded p-2 bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
@@ -79,7 +81,7 @@ export default function ResetPasswordModal({ open, onClose, user }) {
               onClick={onClose}
               className="px-4 py-2 rounded bg-gray-300 dark:bg-gray-700 hover:bg-gray-400 dark:hover:bg-gray-600"
             >
-              Cancel
+              {t("Admin.Common.buttons.cancel")}
             </button>
             <button
               type="submit"
@@ -88,7 +90,9 @@ export default function ResetPasswordModal({ open, onClose, user }) {
                 loading ? "bg-gray-500 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-500"
               }`}
             >
-              {loading ? "Saving…" : "Reset Password"}
+              {loading
+                ? t("Admin.Common.labels.saving")
+                : t("Admin.Users.buttons.resetPassword")}
             </button>
           </div>
         </form>

--- a/frontend/src/features/admin/UserManager.jsx
+++ b/frontend/src/features/admin/UserManager.jsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { API } from "../../shared/config";
 import { COUNTRIES, LANG_LABELS, AVAILABLE_LANGUAGES } from "../../shared/constants";
 import NotificationModal from "../../components/NotificationModal";
 import AddUserModal from "./AddUserModal";
 import ResetPasswordModal from "./ResetPasswordModal";
+import { useTranslation } from "react-i18next";
 
 export default function UserManager() {
+  const { t } = useTranslation();
+  const userKey = (user) => user?._id || user?.id;
   const [users, setUsers] = useState([]);
   const [editingId, setEditingId] = useState(null);
   const [editForm, setEditForm] = useState({});
@@ -22,7 +25,7 @@ export default function UserManager() {
   // ────────────────────────────────
   //  Load all users
   // ────────────────────────────────
-  async function fetchUsers() {
+  const fetchUsers = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -32,22 +35,22 @@ export default function UserManager() {
       setUsers(Array.isArray(data) ? data : []);
     } catch (err) {
       console.error(err);
-      setError(err.message);
+      setError(t("Admin.Users.messages.loadError", { message: err.message }));
       setUsers([]);
     } finally {
       setLoading(false);
     }
-  }
+  }, [t]);
 
   useEffect(() => {
     fetchUsers();
-  }, []);
+  }, [fetchUsers]);
 
   // ────────────────────────────────
   //  Editing & Saving
   // ────────────────────────────────
   const startEdit = (u) => {
-    setEditingId(u._id || u.id);
+    setEditingId(userKey(u));
     setEditForm({
       fullName: u.fullName || "",
       username: u.username || "",
@@ -101,13 +104,13 @@ const saveEdit = async (u) => {
     const data = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(data?.message || `Save failed (${res.status})`);
 
-    setSaveMsg("✅ Saved");
+    setSaveMsg(t("Admin.Common.messages.saved"));
     setEditingId(null);
     setEditForm({});
     await fetchUsers();
   } catch (err) {
     console.error(err);
-    setSaveMsg(`❌ ${err.message}`);
+    setSaveMsg(t("Admin.Users.messages.saveError", { message: err.message }));
   } finally {
     setTimeout(() => setSaveMsg(null), 2500);
   }
@@ -142,13 +145,13 @@ const saveEdit = async (u) => {
             const data = await res.json().catch(() => ({}));
             if (!res.ok) throw new Error(data?.message || `Failed (${res.status})`);
 
-            setUsers((prev) => prev.filter((u) => !selected.has(u._id)));
+            setUsers((prev) => prev.filter((u) => !selected.has(userKey(u))));
             setSelected(new Set());
-            setSaveMsg(`🗑️ Deleted ${ids.length} user(s)`);
+            setSaveMsg(t("Admin.Common.messages.deleted", { count: ids.length }));
             setTimeout(() => setSaveMsg(null), 2500);
         } catch (err) {
             console.error(err);
-            setSaveMsg(`❌ ${err.message}`);
+            setSaveMsg(t("Admin.Users.messages.deleteError", { message: err.message }));
         }
     };
     const filteredUsers = useMemo(() => {
@@ -167,20 +170,20 @@ const saveEdit = async (u) => {
   return (
     <div className="p-4 text-gray-900 dark:text-gray-100">
         <div className="flex items-center justify-between mb-4 flex-wrap gap-2">
-        <h2 className="text-2xl font-semibold">User Manager</h2>
+        <h2 className="text-2xl font-semibold">{t("Admin.Users.title")}</h2>
 
         <div className="flex items-center gap-2">
             <button
                 onClick={() => setAddOpen(true)}
                 className="px-3 py-1 rounded bg-blue-600 hover:bg-blue-500 text-white"
             >
-                + Add New User
+                + {t("Admin.Users.buttons.add")}
             </button>
             <input
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search name, username, or email…"
+            placeholder={t("Admin.Users.searchPlaceholder")}
             className="px-3 py-1 rounded-xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
             />
 
@@ -194,7 +197,7 @@ const saveEdit = async (u) => {
                         : "bg-red-600 hover:bg-red-500"
                     }`}
                 >
-                    Delete Selected ({selected.size})
+                    {t("Admin.Users.buttons.deleteSelected", { count: selected.size })}
                 </button>
             )}
 
@@ -202,12 +205,12 @@ const saveEdit = async (u) => {
             onClick={fetchUsers}
             className="px-3 py-1 rounded bg-gray-300 dark:bg-gray-700 hover:bg-gray-400 dark:hover:bg-gray-600"
             >
-            Refresh
+            {t("Admin.Common.buttons.refresh")}
             </button>
         </div>
         </div>
 
-      {loading && <div>Loading users…</div>}
+      {loading && <div>{t("Admin.Users.messages.loading")}</div>}
       {error && (
         <div className="p-2 rounded bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
           {error}
@@ -234,29 +237,30 @@ const saveEdit = async (u) => {
                 }
             />
             </th>
-                <th className="p-2 text-left">Username</th>
-                <th className="p-2 text-left">Email</th>
-                <th className="p-2 text-left">Full Name</th>
-                <th className="p-2 text-left">Gender</th>
-                <th className="p-2 text-left">Country</th>
-                <th className="p-2 text-left">Language</th>
-                <th className="p-2 text-left">Health</th>
-                <th className="p-2 text-center w-32">Actions</th>
+                <th className="p-2 text-left">{t("Admin.Users.table.username")}</th>
+                <th className="p-2 text-left">{t("Admin.Users.table.email")}</th>
+                <th className="p-2 text-left">{t("Admin.Users.table.fullName")}</th>
+                <th className="p-2 text-left">{t("Admin.Users.table.gender")}</th>
+                <th className="p-2 text-left">{t("Admin.Users.table.country")}</th>
+                <th className="p-2 text-left">{t("Admin.Users.table.language")}</th>
+                <th className="p-2 text-left">{t("Admin.Users.table.health")}</th>
+                <th className="p-2 text-center w-32">{t("Admin.Users.table.actions")}</th>
             </tr>
           </thead>
           <tbody>
             {filteredUsers.map((u) => {
-              const isEditing = editingId === (u._id || u.id);
+              const rowKey = userKey(u);
+              const isEditing = editingId === rowKey;
               return (
                 <tr
-                  key={u._id || u.id}
+                  key={rowKey}
                   className="border-t border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800"
                 >
                   <td className="p-2">
                     <input
                     type="checkbox"
-                    checked={selected.has(u._id)}
-                    onChange={() => toggleSelect(u._id)}
+                    checked={selected.has(rowKey)}
+                    onChange={() => toggleSelect(rowKey)}
                     />
                   </td>
 
@@ -293,9 +297,9 @@ const saveEdit = async (u) => {
                           onChange={handleChange}
                           className="w-full rounded bg-gray-100 dark:bg-gray-900 border border-gray-400 dark:border-gray-600 p-1"
                         >
-                          <option value="male">Male</option>
-                          <option value="female">Female</option>
-                          <option value="other">Other</option>
+                          <option value="male">{t("Admin.Users.gender.male")}</option>
+                          <option value="female">{t("Admin.Users.gender.female")}</option>
+                          <option value="other">{t("Admin.Users.gender.other")}</option>
                         </select>
                       </td>
                       <td className="p-2">
@@ -305,7 +309,7 @@ const saveEdit = async (u) => {
                           onChange={handleChange}
                           className="w-full rounded bg-gray-100 dark:bg-gray-900 border border-gray-400 dark:border-gray-600 p-1"
                         >
-                          <option value="">Select Country</option>
+                          <option value="">{t("Admin.Users.select.country")}</option>
                           {COUNTRIES.map((c) => (
                             <option key={c.code} value={c.code}>
                               {c.flag} {c.name}
@@ -320,7 +324,7 @@ const saveEdit = async (u) => {
                           onChange={handleChange}
                           className="w-full rounded bg-gray-100 dark:bg-gray-900 border border-gray-400 dark:border-gray-600 p-1"
                         >
-                          <option value="">Select Language</option>
+                          <option value="">{t("Admin.Users.select.language")}</option>
                           {(COUNTRIES.find(c => c.code === editForm.country)?.languages ||
                             AVAILABLE_LANGUAGES
                           ).map((lang) => (
@@ -344,7 +348,9 @@ const saveEdit = async (u) => {
                             </label>
                           ))}
                         </div>
-                        <label className="block text-xs mt-1">Allergens</label>
+                        <label className="block text-xs mt-1">
+                          {t("Admin.Users.labels.allergens")}
+                        </label>
                         <input
                           name="Allergens"
                           value={editForm.Allergens}
@@ -359,7 +365,7 @@ const saveEdit = async (u) => {
                             onChange={handleChange}
                             className="mr-1"
                           />
-                          Diabetic
+                          {t("Admin.Users.labels.diabetic")}
                         </label>
                       </td>
                       <td className="p-2 text-center">
@@ -367,24 +373,26 @@ const saveEdit = async (u) => {
                           onClick={() => saveEdit(u)}
                           className="bg-green-600 hover:bg-green-500 text-white px-3 py-1 rounded mr-1"
                         >
-                          Save
+                          {t("Admin.Common.buttons.save")}
                         </button>
                         <button
                           onClick={cancelEdit}
                           className="bg-gray-500 hover:bg-gray-400 text-white px-3 py-1 rounded"
                         >
-                          Cancel
+                          {t("Admin.Common.buttons.cancel")}
                         </button>
                       </td>
                     </>
                   ) : (
                     <>
-                      <td className="p-2">{u.username || "—"}</td>
-                      <td className="p-2">{u.email || "—"}</td>
-                      <td className="p-2">{u.fullName}</td>
-                      <td className="p-2 capitalize">{u.gender}</td>
-                      <td className="p-2">{u.country}</td>
-                      <td className="p-2">{u.language}</td>
+                      <td className="p-2">{u.username || t("Admin.Users.table.empty")}</td>
+                      <td className="p-2">{u.email || t("Admin.Users.table.empty")}</td>
+                      <td className="p-2">{u.fullName || t("Admin.Users.table.empty")}</td>
+                      <td className="p-2 capitalize">
+                        {t(`Admin.Users.gender.${u.gender || "other"}`)}
+                      </td>
+                      <td className="p-2">{u.country || t("Admin.Users.table.empty")}</td>
+                      <td className="p-2">{LANG_LABELS[u.language] || u.language || t("Admin.Users.table.empty")}</td>
                       <td className="p-2">
                         <div className="flex flex-wrap gap-1 text-xs">
                           {["R","S","G","M","A","W","K","Y"].filter(k => u[k]).map(k => (
@@ -393,11 +401,15 @@ const saveEdit = async (u) => {
                         </div>
                         {u.Allergens?.length > 0 && (
                           <div className="text-xs mt-1">
-                            🧂 {u.Allergens.join(", ")}
+                            {t("Admin.Users.labels.allergensPrefix", {
+                              list: u.Allergens.join(", "),
+                            })}
                           </div>
                         )}
                         {u.Diabetic && (
-                          <div className="text-xs text-red-600 dark:text-red-400">Diabetic</div>
+                          <div className="text-xs text-red-600 dark:text-red-400">
+                            {t("Admin.Users.labels.diabetic")}
+                          </div>
                         )}
                       </td>
                       <td className="p-2 text-center">
@@ -405,13 +417,13 @@ const saveEdit = async (u) => {
                           onClick={() => startEdit(u)}
                           className="text-blue-600 dark:text-blue-400 hover:underline"
                         >
-                          Edit
+                          {t("Admin.Common.buttons.edit")}
                         </button>
                         <button
                             onClick={() => setResetTarget(u)}
                             className="text-red-600 dark:text-red-400 hover:underline ml-2"
                             >
-                            Reset Password
+                            {t("Admin.Users.buttons.resetPassword")}
                         </button>
                       </td>
                     </>
@@ -422,7 +434,7 @@ const saveEdit = async (u) => {
             {filteredUsers.length === 0 && !loading && !error && (
               <tr>
                 <td colSpan="9" className="p-3 text-center text-gray-500 dark:text-gray-400">
-                  No users found.
+                  {t("Admin.Users.table.emptyState")}
                 </td>
               </tr>
             )}
@@ -445,18 +457,18 @@ const saveEdit = async (u) => {
             onClose={() => setAddOpen(false)}
             onAdded={(newUser) => {
                 setUsers((prev) => [newUser, ...prev]);
-                setSaveMsg("✅ User added successfully");
+                setSaveMsg(t("Admin.Users.messages.added"));
                 setTimeout(() => setSaveMsg(null), 2500);
             }}
         />
         <NotificationModal
             open={confirmOpen}
-            title="Confirm deletion"
-            message={`Are you sure you want to delete ${selected.size} selected user(s)? This cannot be undone.`}
+            title={t("Admin.Users.modals.deleteTitle")}
+            message={t("Admin.Users.modals.deleteMessage", { count: selected.size })}
             onClose={() => setConfirmOpen(false)}
             onConfirm={confirmDelete}
-            confirmText="Delete"
-            cancelText="Cancel"
+            confirmText={t("Admin.Common.buttons.delete")}
+            cancelText={t("Admin.Common.buttons.cancel")}
         />
     </div>
   );

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -370,5 +370,148 @@
       "noMatch": "Passwörter stimmen nicht überein.",
       "missing": "Pflichtfelder fehlen:"
     }
+  },
+  "Admin": {
+    "Common": {
+      "buttons": {
+        "search": "Suchen",
+        "refresh": "Aktualisieren",
+        "save": "Speichern",
+        "cancel": "Abbrechen",
+        "edit": "Bearbeiten",
+        "delete": "Löschen",
+        "deleteSelected": "Ausgewählte löschen ({{count}})"
+      },
+      "labels": {
+        "viewLanguage": "Anzeigesprache:",
+        "none": "Keine",
+        "loading": "Lade…",
+        "noImage": "Kein Bild",
+        "imageUnavailable": "Bild nicht verfügbar",
+        "saving": "Speichere…"
+      },
+      "messages": {
+        "saved": "✅ Gespeichert",
+        "deleted": "🗑️ {{count}} Element(e) gelöscht",
+        "added": "✅ Erfolgreich hinzugefügt",
+        "error": "❌ {{message}}"
+      }
+    },
+    "Foods": {
+      "title": "Essensverwaltung",
+      "searchPlaceholder": "Gericht, Kategorie oder Barcode suchen…",
+      "buttons": {
+        "addFood": "Gericht hinzufügen"
+      },
+      "columns": {
+        "image": "Bild",
+        "barcode": "Barcode",
+        "dish": "Gericht",
+        "category": "Kategorie",
+        "description": "Beschreibung",
+        "allergens": "Allergene",
+        "diabetic": "Diabetikerfreundlich",
+        "contains": "Allergen-Kennzeichen",
+        "actions": "Aktionen"
+      },
+      "forms": {
+        "dish": "Gericht ({{language}})",
+        "category": "Kategorie ({{language}})",
+        "description": "Beschreibung ({{language}})"
+      },
+      "messages": {
+        "loadError": "Fehler beim Laden der Gerichte: {{message}}",
+        "saveError": "Gericht konnte nicht gespeichert werden: {{message}}",
+        "deleteError": "Gerichte konnten nicht gelöscht werden: {{message}}",
+        "confirmDeleteMany": "{{count}} Gericht(e) löschen?",
+        "confirmDeleteOne": "Dieses Gericht löschen?"
+      },
+      "modals": {
+        "addTitle": "Neues Gericht hinzufügen",
+        "barcode": "Barcode",
+        "baseCategory": "Kategorie",
+        "diabeticFriendly": "Diabetikerfreundlich",
+        "containsFlags": "Allergen-Kennzeichen"
+      }
+    },
+    "Users": {
+      "title": "Benutzerverwaltung",
+      "searchPlaceholder": "Name, Benutzername oder E-Mail suchen…",
+      "buttons": {
+        "add": "Benutzer hinzufügen",
+        "deleteSelected": "Ausgewählte löschen ({{count}})",
+        "resetPassword": "Passwort zurücksetzen"
+      },
+      "messages": {
+        "loading": "Benutzer werden geladen…",
+        "loadError": "Fehler beim Laden der Benutzer: {{message}}",
+        "saveError": "Benutzer konnte nicht gespeichert werden: {{message}}",
+        "deleteError": "Benutzer konnten nicht gelöscht werden: {{message}}",
+        "added": "✅ Benutzer erfolgreich hinzugefügt"
+      },
+      "table": {
+        "username": "Benutzername",
+        "email": "E-Mail-Adresse",
+        "fullName": "Vollständiger Name",
+        "gender": "Geschlecht",
+        "country": "Land",
+        "language": "Sprache",
+        "health": "Gesundheit",
+        "actions": "Aktionen",
+        "empty": "—",
+        "emptyState": "Keine Benutzer gefunden."
+      },
+      "labels": {
+        "healthFlags": "Gesundheitsindikatoren",
+        "allergens": "Allergene",
+        "allergensPrefix": "🧂 {{list}}",
+        "diabetic": "Diabetiker"
+      },
+      "fields": {
+        "username": "Benutzername",
+        "email": "E-Mail-Adresse",
+        "password": "Passwort",
+        "confirmPassword": "Passwort bestätigen",
+        "fullName": "Vollständiger Name",
+        "phone": "Telefonnummer",
+        "address": "Adresse",
+        "allergens": "Allergene (durch Komma getrennt)",
+        "countryPlaceholder": "Land (nur UI)",
+        "languagePlaceholder": "Sprache (nur UI)"
+      },
+      "select": {
+        "country": "Land auswählen",
+        "language": "Sprache auswählen"
+      },
+      "gender": {
+        "male": "Männlich",
+        "female": "Weiblich",
+        "other": "Divers"
+      },
+      "modals": {
+        "addTitle": "Neuen Benutzer hinzufügen",
+        "deleteTitle": "Löschen bestätigen",
+        "deleteMessage": "Möchten Sie {{count}} ausgewählte Benutzer wirklich löschen? Dies kann nicht rückgängig gemacht werden."
+      },
+      "add": {
+        "errors": {
+          "passwordMismatch": "Passwörter stimmen nicht überein.",
+          "fullNameRequired": "Der vollständige Name ist erforderlich.",
+          "generic": "Benutzer konnte nicht hinzugefügt werden: {{message}}"
+        }
+      },
+      "reset": {
+        "success": "Passwort erfolgreich zurückgesetzt ✅",
+        "errors": {
+          "passwordMismatch": "Passwörter stimmen nicht überein.",
+          "generic": "Passwort konnte nicht zurückgesetzt werden: {{message}}"
+        },
+        "title": "Passwort für {{name}} zurücksetzen",
+        "fields": {
+          "newPassword": "Neues Passwort",
+          "confirmPassword": "Neues Passwort bestätigen"
+        }
+      }
+    }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -374,5 +374,148 @@
       "noMatch": "Passwords do not match.",
       "missing": "Required field(s) missing:"
     }
+  },
+  "Admin": {
+    "Common": {
+      "buttons": {
+        "search": "Search",
+        "refresh": "Refresh",
+        "save": "Save",
+        "cancel": "Cancel",
+        "edit": "Edit",
+        "delete": "Delete",
+        "deleteSelected": "Delete Selected ({{count}})"
+      },
+      "labels": {
+        "viewLanguage": "View language:",
+        "none": "None",
+        "loading": "Loading…",
+        "noImage": "No image",
+        "imageUnavailable": "Image unavailable",
+        "saving": "Saving…"
+      },
+      "messages": {
+        "saved": "✅ Saved",
+        "deleted": "🗑️ Deleted {{count}} item(s)",
+        "added": "✅ Added successfully",
+        "error": "❌ {{message}}"
+      }
+    },
+    "Foods": {
+      "title": "Food Manager",
+      "searchPlaceholder": "Search dish, category or barcode…",
+      "buttons": {
+        "addFood": "Add Food"
+      },
+      "columns": {
+        "image": "Image",
+        "barcode": "Barcode",
+        "dish": "Dish",
+        "category": "Category",
+        "description": "Description",
+        "allergens": "Allergens",
+        "diabetic": "Diabetic",
+        "contains": "Contains Flags",
+        "actions": "Actions"
+      },
+      "forms": {
+        "dish": "Dish ({{language}})",
+        "category": "Category ({{language}})",
+        "description": "Description ({{language}})"
+      },
+      "messages": {
+        "loadError": "Failed to load foods: {{message}}",
+        "saveError": "Failed to save food: {{message}}",
+        "deleteError": "Failed to delete foods: {{message}}",
+        "confirmDeleteMany": "Delete {{count}} food item(s)?",
+        "confirmDeleteOne": "Delete this food?"
+      },
+      "modals": {
+        "addTitle": "Add New Food",
+        "barcode": "Barcode",
+        "baseCategory": "Category",
+        "diabeticFriendly": "Diabetic Friendly",
+        "containsFlags": "Contains Flags"
+      }
+    },
+    "Users": {
+      "title": "User Manager",
+      "searchPlaceholder": "Search name, username, or email…",
+      "buttons": {
+        "add": "Add User",
+        "deleteSelected": "Delete Selected ({{count}})",
+        "resetPassword": "Reset Password"
+      },
+      "messages": {
+        "loading": "Loading users…",
+        "loadError": "Failed to load users: {{message}}",
+        "saveError": "Failed to save user: {{message}}",
+        "deleteError": "Failed to delete users: {{message}}",
+        "added": "✅ User added successfully"
+      },
+      "table": {
+        "username": "Username",
+        "email": "Email",
+        "fullName": "Full Name",
+        "gender": "Gender",
+        "country": "Country",
+        "language": "Language",
+        "health": "Health",
+        "actions": "Actions",
+        "empty": "—",
+        "emptyState": "No users found."
+      },
+      "labels": {
+        "healthFlags": "Health Flags",
+        "allergens": "Allergens",
+        "allergensPrefix": "🧂 {{list}}",
+        "diabetic": "Diabetic"
+      },
+      "fields": {
+        "username": "Username",
+        "email": "Email",
+        "password": "Password",
+        "confirmPassword": "Confirm Password",
+        "fullName": "Full name",
+        "phone": "Phone number",
+        "address": "Address",
+        "allergens": "Allergens (comma separated)",
+        "countryPlaceholder": "Country (UI only)",
+        "languagePlaceholder": "Language (UI only)"
+      },
+      "select": {
+        "country": "Select Country",
+        "language": "Select Language"
+      },
+      "gender": {
+        "male": "Male",
+        "female": "Female",
+        "other": "Other"
+      },
+      "modals": {
+        "addTitle": "Add New User",
+        "deleteTitle": "Confirm deletion",
+        "deleteMessage": "Are you sure you want to delete {{count}} selected user(s)? This cannot be undone."
+      },
+      "add": {
+        "errors": {
+          "passwordMismatch": "Passwords do not match.",
+          "fullNameRequired": "Full name is required.",
+          "generic": "Failed to add user: {{message}}"
+        }
+      },
+      "reset": {
+        "success": "Password reset successfully ✅",
+        "errors": {
+          "passwordMismatch": "Passwords do not match.",
+          "generic": "Failed to reset password: {{message}}"
+        },
+        "title": "Reset Password for {{name}}",
+        "fields": {
+          "newPassword": "New password",
+          "confirmPassword": "Confirm new password"
+        }
+      }
+    }
   }
 }

--- a/frontend/src/locales/fi.json
+++ b/frontend/src/locales/fi.json
@@ -359,5 +359,148 @@
       "noMatch": "Salasanat eivät täsmää.",
       "missing": "Pakolliset kentät puuttuvat:"
     }
+  },
+  "Admin": {
+    "Common": {
+      "buttons": {
+        "search": "Haku",
+        "refresh": "Päivitä",
+        "save": "Tallenna",
+        "cancel": "Peruuta",
+        "edit": "Muokkaa",
+        "delete": "Poista",
+        "deleteSelected": "Poista valitut ({{count}})"
+      },
+      "labels": {
+        "viewLanguage": "Näyttökieli:",
+        "none": "Ei mitään",
+        "loading": "Ladataan…",
+        "noImage": "Ei kuvaa",
+        "imageUnavailable": "Kuva ei ole saatavilla",
+        "saving": "Tallennetaan…"
+      },
+      "messages": {
+        "saved": "✅ Tallennettu",
+        "deleted": "🗑️ Poistettiin {{count}} kohdetta",
+        "added": "✅ Lisätty onnistuneesti",
+        "error": "❌ {{message}}"
+      }
+    },
+    "Foods": {
+      "title": "Ruokahallinta",
+      "searchPlaceholder": "Hae ruokalajia, kategoriaa tai viivakoodia…",
+      "buttons": {
+        "addFood": "Lisää ruoka"
+      },
+      "columns": {
+        "image": "Kuva",
+        "barcode": "Viivakoodi",
+        "dish": "Ruoka",
+        "category": "Kategoria",
+        "description": "Kuvaus",
+        "allergens": "Allergeenit",
+        "diabetic": "Diabeetikoille sopiva",
+        "contains": "Allergeeniliput",
+        "actions": "Toiminnot"
+      },
+      "forms": {
+        "dish": "Ruoka ({{language}})",
+        "category": "Kategoria ({{language}})",
+        "description": "Kuvaus ({{language}})"
+      },
+      "messages": {
+        "loadError": "Ruokien lataus epäonnistui: {{message}}",
+        "saveError": "Ruoan tallennus epäonnistui: {{message}}",
+        "deleteError": "Ruokien poisto epäonnistui: {{message}}",
+        "confirmDeleteMany": "Poistetaanko {{count}} ruokaa?",
+        "confirmDeleteOne": "Poistetaanko tämä ruoka?"
+      },
+      "modals": {
+        "addTitle": "Lisää uusi ruoka",
+        "barcode": "Viivakoodi",
+        "baseCategory": "Kategoria",
+        "diabeticFriendly": "Diabeetikoille sopiva",
+        "containsFlags": "Allergeeniliput"
+      }
+    },
+    "Users": {
+      "title": "Käyttäjähallinta",
+      "searchPlaceholder": "Hae nimeä, käyttäjätunnusta tai sähköpostia…",
+      "buttons": {
+        "add": "Lisää käyttäjä",
+        "deleteSelected": "Poista valitut ({{count}})",
+        "resetPassword": "Palauta salasana"
+      },
+      "messages": {
+        "loading": "Käyttäjiä ladataan…",
+        "loadError": "Käyttäjien lataus epäonnistui: {{message}}",
+        "saveError": "Käyttäjän tallennus epäonnistui: {{message}}",
+        "deleteError": "Käyttäjien poisto epäonnistui: {{message}}",
+        "added": "✅ Käyttäjä lisättiin onnistuneesti"
+      },
+      "table": {
+        "username": "Käyttäjätunnus",
+        "email": "Sähköposti",
+        "fullName": "Koko nimi",
+        "gender": "Sukupuoli",
+        "country": "Maa",
+        "language": "Kieli",
+        "health": "Terveys",
+        "actions": "Toiminnot",
+        "empty": "—",
+        "emptyState": "Käyttäjiä ei löytynyt."
+      },
+      "labels": {
+        "healthFlags": "Terveysliput",
+        "allergens": "Allergeenit",
+        "allergensPrefix": "🧂 {{list}}",
+        "diabetic": "Diabeetikko"
+      },
+      "fields": {
+        "username": "Käyttäjätunnus",
+        "email": "Sähköposti",
+        "password": "Salasana",
+        "confirmPassword": "Vahvista salasana",
+        "fullName": "Koko nimi",
+        "phone": "Puhelinnumero",
+        "address": "Osoite",
+        "allergens": "Allergeenit (pilkuilla eroteltuna)",
+        "countryPlaceholder": "Maa (vain käyttöliittymä)",
+        "languagePlaceholder": "Kieli (vain käyttöliittymä)"
+      },
+      "select": {
+        "country": "Valitse maa",
+        "language": "Valitse kieli"
+      },
+      "gender": {
+        "male": "Mies",
+        "female": "Nainen",
+        "other": "Muu"
+      },
+      "modals": {
+        "addTitle": "Lisää uusi käyttäjä",
+        "deleteTitle": "Vahvista poisto",
+        "deleteMessage": "Haluatko varmasti poistaa {{count}} valittua käyttäjää? Toimintoa ei voi perua."
+      },
+      "add": {
+        "errors": {
+          "passwordMismatch": "Salasanat eivät täsmää.",
+          "fullNameRequired": "Koko nimi on pakollinen.",
+          "generic": "Käyttäjän lisääminen epäonnistui: {{message}}"
+        }
+      },
+      "reset": {
+        "success": "Salasana palautettiin onnistuneesti ✅",
+        "errors": {
+          "passwordMismatch": "Salasanat eivät täsmää.",
+          "generic": "Salasanan palautus epäonnistui: {{message}}"
+        },
+        "title": "Palauta salasana käyttäjälle {{name}}",
+        "fields": {
+          "newPassword": "Uusi salasana",
+          "confirmPassword": "Vahvista uusi salasana"
+        }
+      }
+    }
   }
 }

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -373,5 +373,148 @@
       "noMatch": "הסיסמאות אינן תואמות.",
       "missing": "חסרים שדות נדרשים:"
     }
+  },
+  "Admin": {
+    "Common": {
+      "buttons": {
+        "search": "חיפוש",
+        "refresh": "רענון",
+        "save": "שמירה",
+        "cancel": "ביטול",
+        "edit": "עריכה",
+        "delete": "מחיקה",
+        "deleteSelected": "מחיקת פריטים נבחרים ({{count}})"
+      },
+      "labels": {
+        "viewLanguage": "שפת תצוגה:",
+        "none": "אין",
+        "loading": "טוען…",
+        "noImage": "אין תמונה",
+        "imageUnavailable": "התמונה אינה זמינה",
+        "saving": "שומר…"
+      },
+      "messages": {
+        "saved": "✅ נשמר",
+        "deleted": "🗑️ נמחקו {{count}} פריטים",
+        "added": "✅ נוסף בהצלחה",
+        "error": "❌ {{message}}"
+      }
+    },
+    "Foods": {
+      "title": "ניהול מנות",
+      "searchPlaceholder": "חפש מנה, קטגוריה או ברקוד…",
+      "buttons": {
+        "addFood": "הוסף מנה"
+      },
+      "columns": {
+        "image": "תמונה",
+        "barcode": "ברקוד",
+        "dish": "מנה",
+        "category": "קטגוריה",
+        "description": "תיאור",
+        "allergens": "אלרגנים",
+        "diabetic": "מתאים לסוכרתיים",
+        "contains": "סמלי אלרגנים",
+        "actions": "פעולות"
+      },
+      "forms": {
+        "dish": "מנה ({{language}})",
+        "category": "קטגוריה ({{language}})",
+        "description": "תיאור ({{language}})"
+      },
+      "messages": {
+        "loadError": "טעינת המנות נכשלה: {{message}}",
+        "saveError": "שמירת המנה נכשלה: {{message}}",
+        "deleteError": "מחיקת המנות נכשלה: {{message}}",
+        "confirmDeleteMany": "למחוק {{count}} מנות?",
+        "confirmDeleteOne": "למחוק את המנה הזו?"
+      },
+      "modals": {
+        "addTitle": "הוסף מנה חדשה",
+        "barcode": "ברקוד",
+        "baseCategory": "קטגוריה",
+        "diabeticFriendly": "מתאים לסוכרתיים",
+        "containsFlags": "סמלי אלרגנים"
+      }
+    },
+    "Users": {
+      "title": "ניהול משתמשים",
+      "searchPlaceholder": "חפש שם, שם משתמש או אימייל…",
+      "buttons": {
+        "add": "הוסף משתמש",
+        "deleteSelected": "מחיקת משתמשים נבחרים ({{count}})",
+        "resetPassword": "איפוס סיסמה"
+      },
+      "messages": {
+        "loading": "טוען משתמשים…",
+        "loadError": "טעינת המשתמשים נכשלה: {{message}}",
+        "saveError": "שמירת המשתמש נכשלה: {{message}}",
+        "deleteError": "מחיקת המשתמשים נכשלה: {{message}}",
+        "added": "✅ המשתמש נוסף בהצלחה"
+      },
+      "table": {
+        "username": "שם משתמש",
+        "email": "אימייל",
+        "fullName": "שם מלא",
+        "gender": "מגדר",
+        "country": "מדינה",
+        "language": "שפה",
+        "health": "בריאות",
+        "actions": "פעולות",
+        "empty": "—",
+        "emptyState": "לא נמצאו משתמשים."
+      },
+      "labels": {
+        "healthFlags": "דגלי בריאות",
+        "allergens": "אלרגנים",
+        "allergensPrefix": "🧂 {{list}}",
+        "diabetic": "סוכרתי"
+      },
+      "fields": {
+        "username": "שם משתמש",
+        "email": "אימייל",
+        "password": "סיסמה",
+        "confirmPassword": "אישור סיסמה",
+        "fullName": "שם מלא",
+        "phone": "מספר טלפון",
+        "address": "כתובת",
+        "allergens": "אלרגנים (מופרדים בפסיקים)",
+        "countryPlaceholder": "מדינה (לממשק בלבד)",
+        "languagePlaceholder": "שפה (לממשק בלבד)"
+      },
+      "select": {
+        "country": "בחר מדינה",
+        "language": "בחר שפה"
+      },
+      "gender": {
+        "male": "זכר",
+        "female": "נקבה",
+        "other": "אחר"
+      },
+      "modals": {
+        "addTitle": "הוסף משתמש חדש",
+        "deleteTitle": "אישור מחיקה",
+        "deleteMessage": "האם למחוק {{count}} משתמשים נבחרים? פעולה זו לא ניתנת לביטול."
+      },
+      "add": {
+        "errors": {
+          "passwordMismatch": "הסיסמאות אינן תואמות.",
+          "fullNameRequired": "שם מלא הוא שדה חובה.",
+          "generic": "הוספת המשתמש נכשלה: {{message}}"
+        }
+      },
+      "reset": {
+        "success": "הסיסמה אופסה בהצלחה ✅",
+        "errors": {
+          "passwordMismatch": "הסיסמאות אינן תואמות.",
+          "generic": "איפוס הסיסמה נכשל: {{message}}"
+        },
+        "title": "איפוס סיסמה עבור {{name}}",
+        "fields": {
+          "newPassword": "סיסמה חדשה",
+          "confirmPassword": "אשר סיסמה חדשה"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the admin foods router to normalise payloads, derive allergens, honour language maps and return stable image URLs
- export the shared list of available languages and harden allergen helpers for string values
- wire the UI to the updated API by sending locale fields from the add-food modal and consuming image URLs and safer TTS descriptions in Meals

## Testing
- npm run lint --prefix frontend *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f54887b8848322a99534e5699e2f9e