### PR TITLE
Unify allergen and pictogram metadata across app

### DIFF
--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -40,6 +40,7 @@ const ttsRoute           = require('../routes/tts');
 const authRoute          = require('../routes/auth');
 const adminUsersRoute    = require("../routes/admin/users");
 const adminFoodsRoute = require("../routes/admin/foods");
+const metaRoute = require("../routes/meta");
 //const adminMealsRoute    = require("../routes/admin/meals");
 //const adminAllergiesRoute = require("../routes/admin/allergies");
 
@@ -151,6 +152,7 @@ app.use('/rooms',         roomsRoute);
 app.use('/tts',           ttsRoute);
 app.use("/admin/users", adminUsersRoute);
 app.use("/admin/foods", adminFoodsRoute);
+app.use("/api/meta", metaRoute);
 
 app.get('/', (_req, res) => {
   res.send('API is live! 🚀');

--- a/backend/models/food.js
+++ b/backend/models/food.js
@@ -1,5 +1,32 @@
 // backend/models/food.js
 const mongoose = require("mongoose");
+const {
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+} = require("../../shared/constants/meta");
+const { derivePictogramsFromAllergens } = require("../../shared/utils/derivePictograms");
+
+const VALID_PICTOGRAMS = new Set(PICTOGRAMS.map((p) => p.key));
+const VALID_ALLERGENS = new Set(ALLERGENS.map((a) => a.code));
+const VALID_ADDITIVES = new Set(ADDITIVES.map((a) => a.code));
+
+function normalizeList(list, allowedSet) {
+  if (!Array.isArray(list)) {
+    if (list == null) return [];
+    list = [list];
+  }
+
+  const unique = new Set();
+  list.forEach((value) => {
+    const normalized = String(value).trim();
+    if (!normalized) return;
+    if (!allowedSet || allowedSet.has(normalized)) {
+      unique.add(normalized);
+    }
+  });
+  return Array.from(unique);
+}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Sub-schema for multilingual text
@@ -37,22 +64,45 @@ const foodSchema = new mongoose.Schema(
       default: {}, // e.g. { en: { dish, desc, category }, de: {...} }
     },
 
-    additives: [String],
-    allergens: [String],
-    pictograms: [String],
+    additives: {
+      type: [String],
+      default: [],
+      set: (vals) => normalizeList(vals, VALID_ADDITIVES),
+      validate: {
+        validator: (vals) => vals.every((val) => VALID_ADDITIVES.has(val)),
+        message: "Invalid additive code",
+      },
+    },
+    allergens: {
+      type: [String],
+      default: [],
+      set: (vals) => normalizeList(vals, VALID_ALLERGENS),
+      validate: {
+        validator: (vals) => vals.every((val) => VALID_ALLERGENS.has(val)),
+        message: "Invalid allergen code",
+      },
+    },
+    pictograms: {
+      type: [String],
+      default: [],
+      set: (vals) => normalizeList(vals, VALID_PICTOGRAMS),
+      validate: {
+        validator: (vals) => vals.every((val) => VALID_PICTOGRAMS.has(val)),
+        message: "Invalid pictogram key",
+      },
+    },
     diabeticFriendly: { type: Boolean, required: true },
-
-    contains_R: Boolean,
-    contains_S: Boolean,
-    contains_G: Boolean,
-    contains_M: Boolean,
-    contains_A: Boolean,
-    contains_W: Boolean,
-    contains_K: Boolean,
-    contains_Y: Boolean,
   },
   { timestamps: true }
 );
+
+foodSchema.set("toJSON", { virtuals: true });
+foodSchema.set("toObject", { virtuals: true });
+
+foodSchema.virtual("derivedPictograms").get(function derive() {
+  if (!Array.isArray(this.allergens)) return [];
+  return derivePictogramsFromAllergens(this.allergens, PICTOGRAMS);
+});
 
 // Indexes
 foodSchema.index({ barcode: 1 });

--- a/backend/routes/admin/foods.js
+++ b/backend/routes/admin/foods.js
@@ -6,6 +6,12 @@ const mongoose = require("mongoose");
 const router = express.Router();
 const Food = require("../../models/food");
 const isAdmin = require("../../middleware/isAdmin");
+const {
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+} = require("../../shared/constants/meta");
+const { derivePictogramsFromAllergens } = require("../../shared/utils/derivePictograms");
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Admin guard
@@ -47,6 +53,31 @@ function parseBool(v) {
   return false;
 }
 
+const VALID_PICTOGRAMS = new Set(PICTOGRAMS.map((p) => p.key));
+const VALID_ALLERGENS = new Set(ALLERGENS.map((a) => a.code));
+const VALID_ADDITIVES = new Set(ADDITIVES.map((a) => a.code));
+
+function sanitizeCodes(values, allowed) {
+  return Array.from(
+    new Set(
+      parseArray(values)
+        .map((val) => String(val).trim())
+        .filter((val) => val && (!allowed || allowed.has(val)))
+    )
+  );
+}
+
+function extractPictogramsFromFlags(body, prefix = "contains_") {
+  const selected = [];
+  PICTOGRAMS.forEach(({ key }) => {
+    const field = `${prefix}${key}`;
+    if (field in body && parseBool(body[field])) {
+      selected.push(key);
+    }
+  });
+  return selected;
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Multer memory storage
 // ──────────────────────────────────────────────────────────────────────────────
@@ -68,7 +99,7 @@ router.get("/", async (req, res) => {
         { barcode: rx },
       ];
     }
-    const foods = await Food.find(filter).sort({ id: -1 }).lean();
+    const foods = await Food.find(filter).sort({ id: -1 }).lean({ virtuals: true });
     foods.forEach((f) => delete f.image);
     res.json(foods);
   } catch (e) {
@@ -112,14 +143,6 @@ router.post("/", upload.single("image"), async (req, res) => {
       allergens,
       pictograms,
       diabeticFriendly,
-      contains_R,
-      contains_S,
-      contains_G,
-      contains_M,
-      contains_A,
-      contains_W,
-      contains_K,
-      contains_Y,
     } = req.body;
 
     if (!barcode || !date || !category || !dish || typeof diabeticFriendly === "undefined") {
@@ -140,8 +163,20 @@ router.post("/", upload.single("image"), async (req, res) => {
     }
 
     // Auto-generate next numeric id
-    const lastFood = await Food.findOne().sort({ id: -1 }).lean();
+    const lastFood = await Food.findOne().sort({ id: -1 }).lean({ virtuals: true });
     const numericId = (lastFood?.id || 0) + 1;
+
+    const normalizedAllergens = sanitizeCodes(allergens, VALID_ALLERGENS);
+    const providedPictograms = sanitizeCodes(pictograms, VALID_PICTOGRAMS);
+    const flagPictograms = extractPictogramsFromFlags(req.body);
+    const derivedFromAllergens = derivePictogramsFromAllergens(
+      normalizedAllergens,
+      PICTOGRAMS
+    );
+
+    const combinedPictograms = Array.from(
+      new Set([...providedPictograms, ...flagPictograms, ...derivedFromAllergens])
+    );
 
     const doc = new Food({
       id: numericId,
@@ -151,19 +186,10 @@ router.post("/", upload.single("image"), async (req, res) => {
       dish: String(dish),
       description: description ?? null,
       translations,
-      additives: parseArray(additives),
-      allergens: parseArray(allergens),
-      pictograms: parseArray(pictograms),
+      additives: sanitizeCodes(additives, VALID_ADDITIVES),
+      allergens: normalizedAllergens,
+      pictograms: combinedPictograms,
       diabeticFriendly: parseBool(diabeticFriendly),
-
-      contains_R: parseBool(contains_R),
-      contains_S: parseBool(contains_S),
-      contains_G: parseBool(contains_G),
-      contains_M: parseBool(contains_M),
-      contains_A: parseBool(contains_A),
-      contains_W: parseBool(contains_W),
-      contains_K: parseBool(contains_K),
-      contains_Y: parseBool(contains_Y),
     });
 
     if (req.file) {
@@ -188,44 +214,72 @@ router.put("/:id", upload.single("image"), async (req, res) => {
   try {
     const q = safeFoodQuery(req.params.id);
     const body = { ...req.body };
+    const updates = {};
+
+    if (typeof body.barcode !== "undefined") updates.barcode = String(body.barcode);
+    if (typeof body.date !== "undefined") updates.date = String(body.date);
+    if (typeof body.category !== "undefined") updates.category = String(body.category);
+    if (typeof body.dish !== "undefined") updates.dish = String(body.dish);
+    if (typeof body.description !== "undefined")
+      updates.description = body.description ?? null;
 
     // Parse translations if provided
     try {
       if (body.translations && typeof body.translations === "string") {
         const parsed = JSON.parse(body.translations);
-        if (typeof parsed === "object") body.translations = parsed;
+        if (typeof parsed === "object") updates.translations = parsed;
+      } else if (body.translations && typeof body.translations === "object") {
+        updates.translations = body.translations;
       }
     } catch (e) {
       console.warn("Invalid translations JSON:", e);
     }
 
     if (body.diabeticFriendly != null)
-      body.diabeticFriendly = parseBool(body.diabeticFriendly);
-    if (body.additives != null) body.additives = parseArray(body.additives);
-    if (body.allergens != null) body.allergens = parseArray(body.allergens);
-    if (body.pictograms != null) body.pictograms = parseArray(body.pictograms);
-    const bools = [
-      "contains_R",
-      "contains_S",
-      "contains_G",
-      "contains_M",
-      "contains_A",
-      "contains_W",
-      "contains_K",
-      "contains_Y",
-    ];
-    for (const k of bools) {
-      if (k in body) body[k] = parseBool(body[k]);
+      updates.diabeticFriendly = parseBool(body.diabeticFriendly);
+
+    if (body.additives != null)
+      updates.additives = sanitizeCodes(body.additives, VALID_ADDITIVES);
+
+    let normalizedAllergens;
+    if (body.allergens != null) {
+      normalizedAllergens = sanitizeCodes(body.allergens, VALID_ALLERGENS);
+      updates.allergens = normalizedAllergens;
+    }
+
+    let normalizedPictograms = null;
+    if (body.pictograms != null)
+      normalizedPictograms = sanitizeCodes(body.pictograms, VALID_PICTOGRAMS);
+
+    const flagPictograms = extractPictogramsFromFlags(body);
+
+    if (normalizedAllergens) {
+      const derived = derivePictogramsFromAllergens(normalizedAllergens, PICTOGRAMS);
+      normalizedPictograms = [
+        ...(normalizedPictograms || []),
+        ...derived,
+      ];
+    }
+
+    if (flagPictograms.length) {
+      normalizedPictograms = [
+        ...(normalizedPictograms || []),
+        ...flagPictograms,
+      ];
+    }
+
+    if (normalizedPictograms) {
+      updates.pictograms = Array.from(new Set(normalizedPictograms));
     }
 
     if (req.file) {
-      body.image = {
+      updates.image = {
         data: req.file.buffer,
         contentType: req.file.mimetype || "image/png",
       };
     }
 
-    const updated = await Food.findOneAndUpdate(q, body, { new: true });
+    const updated = await Food.findOneAndUpdate(q, updates, { new: true });
     if (!updated) return res.status(404).json({ message: "Food not found" });
     res.json(updated);
   } catch (e) {

--- a/backend/routes/admin/users.js
+++ b/backend/routes/admin/users.js
@@ -7,6 +7,7 @@ const isAdmin = require("../../middleware/isAdmin");
 const { safeUserQuery } = require("../../lib/utils");
 const bcrypt = require("bcrypt");
 const Admin = require("../../models/admin");
+const { PICTOGRAMS } = require("../../../shared/constants/meta");
 
 // Apply admin guard to every route here
 router.use(isAdmin);
@@ -19,20 +20,16 @@ router.get("/", async (req, res) => {
     // Always fetch fresh data, not cached docs
     const users = await User.find({}, { passwordHash: 0 }).lean({ getters: true });
 
-    // Normalize fields so checkboxes match backend
-    const normalized = users.map((u) => ({
-      ...u,
-      R: !!u.R,
-      S: !!u.S,
-      G: !!u.G,
-      M: !!u.M,
-      A: !!u.A,
-      W: !!u.W,
-      K: !!u.K,
-      Y: !!u.Y,
-      Diabetic: !!u.Diabetic,
-      // ⚠️ Drop textual allergens — localization handles text in frontend
-    }));
+    const normalized = users.map((u) => {
+      const pictogramFlags = Object.fromEntries(
+        PICTOGRAMS.map(({ key }) => [key, !!u[key]])
+      );
+      return {
+        ...u,
+        ...pictogramFlags,
+        Diabetic: !!u.Diabetic,
+      };
+    });
 
     res.json(normalized);
   } catch (e) {
@@ -92,9 +89,8 @@ router.post("/add", async (req, res) => {
     const hashed = password ? await bcrypt.hash(password, 10) : undefined;
 
     // Normalize allergen flags
-    const allergenKeys = ["R", "S", "G", "M", "A", "W", "K", "Y"];
     const allergenFlags = {};
-    allergenKeys.forEach((key) => {
+    PICTOGRAMS.forEach(({ key }) => {
       allergenFlags[key] = req.body[key] === "on" || req.body[key] === true;
     });
 

--- a/backend/routes/foods.js
+++ b/backend/routes/foods.js
@@ -22,7 +22,7 @@ function safeFoodQuery(idOrString) {
  */
 router.get("/", async (_req, res) => {
   try {
-    const foods = await Food.find().sort({ createdAt: -1 }).lean();
+    const foods = await Food.find().sort({ createdAt: -1 }).lean({ virtuals: true });
     // Hide binary data to avoid sending megabytes
     foods.forEach(f => delete f.image);
     res.json(foods);
@@ -37,7 +37,7 @@ router.get("/", async (_req, res) => {
  */
 router.get("/:barcode", async (req, res) => {
   try {
-    const food = await Food.findOne({ barcode: req.params.barcode }).lean();
+    const food = await Food.findOne({ barcode: req.params.barcode }).lean({ virtuals: true });
     if (!food) return res.status(404).json({ message: "Not found" });
     delete food.image; // remove heavy blob
     res.json(food);

--- a/backend/routes/meta.js
+++ b/backend/routes/meta.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const router = express.Router();
+const {
+  VERSION,
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+} = require("../../shared/constants/meta");
+
+router.get("/init", (_req, res) => {
+  res.json({
+    version: VERSION,
+    pictograms: PICTOGRAMS,
+    allergens: ALLERGENS,
+    additives: ADDITIVES,
+  });
+});
+
+module.exports = router;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const User = require("../models/user");
 const { readSession } = require("../lib/session");
 const { safeUserQuery } = require("../lib/utils");
+const { PICTOGRAMS } = require("../../shared/constants/meta");
 
 const BLOCKED_UPDATE_FIELDS = new Set([
   "passwordHash",
@@ -108,9 +109,7 @@ router.patch("/:id/health", async (req, res) => {
     if (!isAdmin && currentUser.id !== id)
       return res.status(403).json({ message: "Forbidden" });
 
-    const allowedFields = [
-      "R", "S", "G", "M", "A", "W", "K", "Y", "Diabetic"
-    ];
+    const allowedFields = [...PICTOGRAMS.map((p) => p.key), "Diabetic"];
 
     // Pick only allowed fields
     const filtered = Object.fromEntries(

--- a/frontend/src/components/AllergenCheckboxes.jsx
+++ b/frontend/src/components/AllergenCheckboxes.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useMeta } from "../shared/metaContext.jsx";
+
+export function extractSelectedPictograms(values = {}, prefix = "", pictograms = []) {
+  const fieldFor = (key) => (prefix ? `${prefix}${key}` : key);
+
+  return (Array.isArray(pictograms) ? pictograms : [])
+    .map(({ key }) => key)
+    .filter((key) => !!values[fieldFor(key)]);
+}
+
+function AllergenCheckboxes({ values = {}, onChange = () => {}, prefix = "", readOnly = false }) {
+  const { t } = useTranslation();
+  const { pictograms } = useMeta();
+
+  const fieldFor = (key) => (prefix ? `${prefix}${key}` : key);
+
+  const toggle = (key) => {
+    if (readOnly) return;
+    const field = fieldFor(key);
+    onChange({
+      ...values,
+      [field]: !values[field],
+    });
+  };
+
+  if (!Array.isArray(pictograms) || pictograms.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+      {pictograms.map(({ key, icon, tKey }) => (
+        <label
+          key={key}
+          className="flex items-center gap-1 border border-gray-300 dark:border-gray-700 rounded p-1"
+        >
+          <input
+            type="checkbox"
+            checked={!!values[fieldFor(key)]}
+            onChange={() => toggle(key)}
+            disabled={readOnly}
+          />
+          <span>{icon}</span>
+          <span>{t(tKey)}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export default AllergenCheckboxes;

--- a/frontend/src/features/SettingsModal.jsx
+++ b/frontend/src/features/SettingsModal.jsx
@@ -11,6 +11,8 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { AppContext } from "../shared/AppContext";
 import { API } from "../shared/config";
+import AllergenCheckboxes from "../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../shared/metaContext.jsx";
 
 export default function SettingsModal({ onClose }) {
   const { t, i18n } = useTranslation();
@@ -24,20 +26,21 @@ export default function SettingsModal({ onClose }) {
   const [languageError, setLanguageError] = useState(null);
 
   /** ─────────────────────────── Health flags ─────────────────────────── **/
-  // Dynamically get available pictogram keys from i18n
-  const pictograms = t("Meals.Legend.Pictograms", { returnObjects: true });
-  const allergenKeys = Object.keys(pictograms || {});
+  const { pictograms: metaPictograms } = useMeta();
 
-  const [healthFlags, setHealthFlags] = useState(
-    allergenKeys.reduce((acc, k) => ({ ...acc, [k]: !!user?.[k] }), {})
-  );
+  const buildHealthFlags = useMemo(() => {
+    const entries = (metaPictograms || []).map(({ key }) => [key, !!user?.[key]]);
+    return Object.fromEntries(entries);
+  }, [metaPictograms, user]);
+
+  const [healthFlags, setHealthFlags] = useState(buildHealthFlags);
   const [diabetic, setDiabetic] = useState(!!user?.Diabetic);
 
   // Keep sync when user or language changes (so new translations reload)
   useEffect(() => {
-    setHealthFlags(allergenKeys.reduce((acc, k) => ({ ...acc, [k]: !!user?.[k] }), {}));
+    setHealthFlags(buildHealthFlags);
     setDiabetic(!!user?.Diabetic);
-  }, [user, i18n.language]);
+  }, [user, i18n.language, buildHealthFlags]);
 
   /** ─────────────────────────── Language logic ─────────────────────────── **/
   const LANGUAGE_LABELS = useMemo(
@@ -107,9 +110,6 @@ export default function SettingsModal({ onClose }) {
   };
 
   /** ─────────────────────────── Health toggle/save ─────────────────────────── **/
-  const toggleFlag = (key) =>
-    setHealthFlags((prev) => ({ ...prev, [key]: !prev[key] }));
-
   const saveHealth = async () => {
     if (!user) return;
     try {
@@ -317,21 +317,7 @@ export default function SettingsModal({ onClose }) {
                 {t("SettingsModal.health")}
               </h3>
 
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
-                {allergenKeys.map((key) => (
-                  <label
-                    key={key}
-                    className="flex items-center gap-2 border border-gray-300 dark:border-gray-600 rounded p-2"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={!!healthFlags[key]}
-                      onChange={() => toggleFlag(key)}
-                    />
-                    {pictograms[key]}
-                  </label>
-                ))}
-              </div>
+              <AllergenCheckboxes values={healthFlags} onChange={setHealthFlags} />
 
               <label className="flex items-center gap-2 block mt-2">
                 <input

--- a/frontend/src/features/admin/AddFoodModal.jsx
+++ b/frontend/src/features/admin/AddFoodModal.jsx
@@ -2,17 +2,10 @@ import React, { useEffect, useMemo, useState } from "react";
 import { API } from "../../shared/config";
 import { useTranslation } from "react-i18next";
 import { LANG_LABELS } from "../../shared/constants";
-
-const ALLERGEN_KEYS = [
-  { key: "R", icon: "🥩" },
-  { key: "S", icon: "🐷" },
-  { key: "G", icon: "🐔" },
-  { key: "M", icon: "🥛" },
-  { key: "A", icon: "🍷" },
-  { key: "W", icon: "🌾" },
-  { key: "K", icon: "🧄" },
-  { key: "Y", icon: "🌱" },
-];
+import AllergenCheckboxes, {
+  extractSelectedPictograms,
+} from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/metaContext.jsx";
 
 const SUPPORTED_LANGS = ["en", "de", "fi", "he"];
 const safeLangLabel = (lang, t) =>
@@ -20,6 +13,7 @@ const safeLangLabel = (lang, t) =>
 
 export default function AddFoodModal({ onClose, onAdded }) {
   const { t } = useTranslation();
+  const { pictograms } = useMeta();
   const [activeLang, setActiveLang] = useState("en");
   const [file, setFile] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -29,8 +23,6 @@ export default function AddFoodModal({ onClose, onAdded }) {
     barcode: "",
     date: new Date().toISOString().slice(0, 10),
     diabeticFriendly: false,
-    // pictogram flags
-    R: false, S: false, G: false, M: false, A: false, W: false, K: false, Y: false,
     // multilingual content
     translations: {
       en: { dish: "", description: "", category: "" },
@@ -49,6 +41,20 @@ export default function AddFoodModal({ onClose, onAdded }) {
   useEffect(() => {
     setForm((f) => ({ ...f, barcode: nextBarcode() }));
   }, []);
+
+  useEffect(() => {
+    if (!Array.isArray(pictograms)) return;
+    setForm((prev) => {
+      const next = { ...prev };
+      pictograms.forEach(({ key }) => {
+        const field = `contains_${key}`;
+        if (typeof next[field] !== "boolean") {
+          next[field] = false;
+        }
+      });
+      return next;
+    });
+  }, [pictograms]);
 
   const langData = useMemo(() => form.translations[activeLang], [form.translations, activeLang]);
 
@@ -90,8 +96,12 @@ export default function AddFoodModal({ onClose, onAdded }) {
       fd.append("category", en.category);
       fd.append("description", en.description || "");
 
-      // pictograms (booleans)
-      ALLERGEN_KEYS.forEach(({ key }) => fd.append(`contains_${key}`, String(!!form[key])));
+      const selectedPictograms = extractSelectedPictograms(
+        form,
+        "contains_",
+        pictograms
+      );
+      fd.append("pictograms", JSON.stringify(selectedPictograms));
 
       // full multilingual payload
       fd.append("translations", JSON.stringify(form.translations));
@@ -172,25 +182,11 @@ export default function AddFoodModal({ onClose, onAdded }) {
             <p className="font-semibold mb-2">
               {t("Meals.LegendHeadings.Pictograms", "Pictograms")}
             </p>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm">
-              {ALLERGEN_KEYS.map(({ key, icon }) => (
-                <label
-                  key={key}
-                  className="flex items-center gap-2 border border-gray-300 dark:border-gray-700 rounded p-2"
-                >
-                  <input
-                    type="checkbox"
-                    checked={!!form[key]}
-                    onChange={(e) => setForm({ ...form, [key]: e.target.checked })}
-                  />
-                  <span className="text-base">{icon}</span>
-                  <span>
-                    {t(`Meals.Legend.Pictograms.${key}`, key)}
-                    {" (" + key + ")"}
-                  </span>
-                </label>
-              ))}
-            </div>
+            <AllergenCheckboxes
+              values={form}
+              onChange={setForm}
+              prefix="contains_"
+            />
           </div>
 
           {/* Language Tabs */}

--- a/frontend/src/features/admin/AddUserModal.jsx
+++ b/frontend/src/features/admin/AddUserModal.jsx
@@ -1,41 +1,50 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { API } from "../../shared/config";
 import { COUNTRIES, AVAILABLE_LANGUAGES, LANG_LABELS } from "../../shared/constants";
+import AllergenCheckboxes from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/metaContext.jsx";
 
 export default function AddUserModal({ open, onClose, onAdded }) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
 
-  // Same pictogram keys used in UserManager
-  const ALLERGEN_KEYS = [
-    { key: "R", icon: "🥩" },
-    { key: "S", icon: "🐷" },
-    { key: "G", icon: "🐔" },
-    { key: "M", icon: "🥛" },
-    { key: "A", icon: "🍷" },
-    { key: "W", icon: "🌾" },
-    { key: "K", icon: "🧄" },
-    { key: "Y", icon: "🌱" },
-  ];
+  const { pictograms } = useMeta();
 
-  const [form, setForm] = useState({
-    fullName: "",
-    username: "",
-    email: "",
-    password: "",
-    confirmPassword: "",
-    phoneNumber: "",
-    dateOfBirth: "",
-    gender: "other",
-    R: false, S: false, G: false, M: false, A: false, W: false, K: false, Y: false,
-    Diabetic: false,
-    country: "",
-    language: "",
-  });
+  const baseForm = useMemo(() => {
+    const initial = {
+      fullName: "",
+      username: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+      phoneNumber: "",
+      dateOfBirth: "",
+      gender: "other",
+      Diabetic: false,
+      country: "",
+      language: "",
+    };
+    pictograms.forEach(({ key }) => {
+      initial[key] = false;
+    });
+    return initial;
+  }, [pictograms]);
+
+  const [form, setForm] = useState(baseForm);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
   if (!open) return null;
+
+  useEffect(() => {
+    setForm((prev) => {
+      const next = { ...prev };
+      pictograms.forEach(({ key }) => {
+        if (typeof next[key] !== "boolean") next[key] = false;
+      });
+      return next;
+    });
+  }, [pictograms]);
 
   const handleChange = (e) => {
     const { name, type, value, checked } = e.target;
@@ -57,6 +66,10 @@ export default function AddUserModal({ open, onClose, onAdded }) {
 
     setLoading(true);
     try {
+      const allergenFlags = Object.fromEntries(
+        pictograms.map(({ key }) => [key, !!form[key]])
+      );
+
       const payload = {
         id:
           typeof crypto !== "undefined" && crypto.randomUUID
@@ -69,14 +82,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
         phoneNumber: form.phoneNumber.trim() || undefined,
         dateOfBirth: form.dateOfBirth ? new Date(form.dateOfBirth) : undefined,
         gender: form.gender,
-        R: !!form.R,
-        S: !!form.S,
-        G: !!form.G,
-        M: !!form.M,
-        A: !!form.A,
-        W: !!form.W,
-        K: !!form.K,
-        Y: !!form.Y,
+        ...allergenFlags,
         Diabetic: !!form.Diabetic,
         country: form.country,
         language: form.language,
@@ -93,20 +99,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
 
       onAdded?.(data);
       onClose?.();
-      setForm({
-        fullName: "",
-        username: "",
-        email: "",
-        password: "",
-        confirmPassword: "",
-        phoneNumber: "",
-        dateOfBirth: "",
-        gender: "other",
-        R: false, S: false, G: false, M: false, A: false, W: false, K: false, Y: false,
-        Diabetic: false,
-        country: "",
-        language: "",
-      });
+      setForm({ ...baseForm });
     } catch (err) {
       setError(err.message);
     } finally {
@@ -198,22 +191,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
             <div className="text-sm font-semibold mb-1 text-gray-800 dark:text-gray-200">
               {t("Admin.Users.health", "Health Flags")}
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-              {ALLERGEN_KEYS.map(({ key, icon }) => (
-                <label key={key} className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    name={key}
-                    checked={!!form[key]}
-                    onChange={handleChange}
-                  />
-                  <span className="text-sm">
-                    {icon}{" "}
-                    {t(`Meals.Legend.Pictograms.${key}`, key)}
-                  </span>
-                </label>
-              ))}
-            </div>
+            <AllergenCheckboxes values={form} onChange={setForm} />
           </div>
 
           {/* Diabetic, Country, Language */}

--- a/frontend/src/features/admin/FoodManager.jsx
+++ b/frontend/src/features/admin/FoodManager.jsx
@@ -4,17 +4,10 @@ import { API } from "../../shared/config";
 import { useTranslation } from "react-i18next";
 import AddFoodModal from "./AddFoodModal";
 import { QRCodeCanvas } from "qrcode.react";
-
-const ALLERGEN_KEYS = [
-  { key: "R", icon: "🥩" },
-  { key: "S", icon: "🐷" },
-  { key: "G", icon: "🐔" },
-  { key: "M", icon: "🥛" },
-  { key: "A", icon: "🍷" },
-  { key: "W", icon: "🌾" },
-  { key: "K", icon: "🧄" },
-  { key: "Y", icon: "🌱" },
-];
+import AllergenCheckboxes, {
+  extractSelectedPictograms,
+} from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/metaContext.jsx";
 const SUPPORTED_LANGS = ["en", "de", "fi", "he"];
 
 function getLocalized(food, lang) {
@@ -24,6 +17,7 @@ function getLocalized(food, lang) {
 
 export default function FoodManager() {
   const { t, i18n } = useTranslation();
+  const { pictograms: metaPictograms } = useMeta();
   const [foods, setFoods] = useState([]);
   const [query, setQuery] = useState("");
   const [addOpen, setAddOpen] = useState(false);
@@ -62,16 +56,43 @@ export default function FoodManager() {
     });
   }, [foods, query, i18n.language]);
 
+  const pictogramKeys = useMemo(
+    () => metaPictograms.map(({ key }) => key),
+    [metaPictograms]
+  );
+
+  const pictogramMap = useMemo(
+    () => new Map(metaPictograms.map((entry) => [entry.key, entry])),
+    [metaPictograms]
+  );
+
+  const resolvePictogramKeys = (food) => {
+    if (Array.isArray(food?.pictograms) && food.pictograms.length) {
+      return Array.from(new Set(food.pictograms.map((key) => String(key))));
+    }
+    if (Array.isArray(food?.derivedPictograms) && food.derivedPictograms.length) {
+      return Array.from(
+        new Set(food.derivedPictograms.map((key) => String(key)))
+      );
+    }
+    return pictogramKeys.filter(
+      (key) => food?.[`contains_${key}`] || food?.[key]
+    );
+  };
+
   function startEdit(food) {
     setEditingId(food.id);
-    const b = {};
-    ALLERGEN_KEYS.forEach(({ key }) => (b[key] = !!food[`contains_${key}`] || !!food[key]));
+    const baseFlags = {};
+    const selected = new Set(resolvePictogramKeys(food));
+    pictogramKeys.forEach((key) => {
+      baseFlags[`contains_${key}`] = selected.has(key);
+    });
     setEditForm({
       id: food.id,
       barcode: food.barcode || "",
       date: (food.date || "").slice?.(0, 10) || "",
       diabeticFriendly: !!food.diabeticFriendly,
-      ...b,
+      ...baseFlags,
       translations: {
         en: { dish: "", description: "", category: "", ...(food.translations?.en || {}) },
         de: { dish: "", description: "", category: "", ...(food.translations?.de || {}) },
@@ -102,7 +123,12 @@ export default function FoodManager() {
       fd.append("barcode", editForm.barcode || "");
       if (editForm.date) fd.append("date", editForm.date);
       fd.append("diabeticFriendly", String(!!editForm.diabeticFriendly));
-      ALLERGEN_KEYS.forEach(({ key }) => fd.append(`contains_${key}`, String(!!editForm[key])));
+      const selectedPictograms = extractSelectedPictograms(
+        editForm,
+        "contains_",
+        metaPictograms
+      );
+      fd.append("pictograms", JSON.stringify(selectedPictograms));
       fd.append("translations", JSON.stringify(editForm.translations));
       if (editFile) fd.append("image", editFile);
 
@@ -243,18 +269,19 @@ export default function FoodManager() {
                       </td>
                       <td className="p-2">
                         <div className="flex flex-wrap gap-1">
-                          {ALLERGEN_KEYS.filter(({ key }) => f[`contains_${key}`] || f[key]).map(
-                            ({ key, icon }) => (
+                          {resolvePictogramKeys(f).map((key) => {
+                            const meta = pictogramMap.get(key) || { icon: key, tKey: key };
+                            return (
                               <div
                                 key={key}
                                 className="w-8 h-8 flex flex-col items-center justify-center text-xs font-semibold border border-gray-400 dark:border-gray-600 rounded-md"
-                                title={t(`Meals.Legend.Pictograms.${key}`, key)}
+                                title={t(meta.tKey || key, key)}
                               >
-                                <span className="text-base leading-none">{icon}</span>
+                                <span className="text-base leading-none">{meta.icon || key}</span>
                                 <span className="leading-none">{key}</span>
                               </div>
-                            )
-                          )}
+                            );
+                          })}
                         </div>
                       </td>
                       <td className="p-2 text-center whitespace-nowrap">
@@ -371,24 +398,11 @@ export default function FoodManager() {
                         </label>
                       </td>
                       <td className="p-2">
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
-                          {ALLERGEN_KEYS.map(({ key, icon }) => (
-                            <label
-                              key={key}
-                              className="flex items-center gap-1 border border-gray-300 dark:border-gray-700 rounded p-1"
-                            >
-                              <input
-                                type="checkbox"
-                                checked={!!editForm[key]}
-                                onChange={(e) =>
-                                  setEditForm((ef) => ({ ...ef, [key]: e.target.checked }))
-                                }
-                              />
-                              <span>{icon}</span>
-                              <span>{t(`Meals.Legend.Pictograms.${key}`, key)}</span>
-                            </label>
-                          ))}
-                        </div>
+                        <AllergenCheckboxes
+                          values={editForm}
+                          onChange={setEditForm}
+                          prefix="contains_"
+                        />
                       </td>
                       <td className="p-2 text-center whitespace-nowrap">
                         <button

--- a/frontend/src/features/admin/UserManager.jsx
+++ b/frontend/src/features/admin/UserManager.jsx
@@ -12,20 +12,12 @@ import ResetPasswordModal from "./ResetPasswordModal";
 import { useTranslation } from "react-i18next";
 import { useContext } from "react";
 import { AppContext } from "../../shared/AppContext";
+import AllergenCheckboxes from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/metaContext.jsx";
 
 export default function UserManager() {
   const { t } = useTranslation();
-
-  const ALLERGEN_KEYS = [
-    { key: "R", icon: "🥩" },
-    { key: "S", icon: "🐷" },
-    { key: "G", icon: "🐔" },
-    { key: "M", icon: "🥛" },
-    { key: "A", icon: "🍷" },
-    { key: "W", icon: "🌾" },
-    { key: "K", icon: "🧄" },
-    { key: "Y", icon: "🌱" },
-  ];
+  const { pictograms: metaPictograms } = useMeta();
 
   const [users, setUsers] = useState([]);
   const [editingId, setEditingId] = useState(null);
@@ -67,14 +59,23 @@ export default function UserManager() {
   // ────────────────────────────────
   //  Helpers
   // ────────────────────────────────
+  const pictogramMap = useMemo(
+    () => new Map(metaPictograms.map((entry) => [entry.key, entry])),
+    [metaPictograms]
+  );
+
   const pictogramLabel = (key) =>
-    t(`Meals.Legend.Pictograms.${key}`, key);
+    t(pictogramMap.get(key)?.tKey || `Meals.Legend.Pictograms.${key}`, key);
 
   // ────────────────────────────────
   //  Editing & Saving
   // ────────────────────────────────
   const startEdit = (u) => {
     setEditingId(u._id || u.id);
+    const allergenFlags = Object.fromEntries(
+      metaPictograms.map(({ key }) => [key, !!u[key]])
+    );
+
     setEditForm({
       fullName: u.fullName || "",
       username: u.username || "",
@@ -85,10 +86,7 @@ export default function UserManager() {
       country: u.country || "",
       language: u.language || "",
       Diabetic: u.Diabetic ?? false,
-      ...ALLERGEN_KEYS.reduce(
-        (acc, { key }) => ({ ...acc, [key]: !!u[key] }),
-        {}
-      ),
+      ...allergenFlags,
     });
   };
 
@@ -378,23 +376,7 @@ export default function UserManager() {
                         </select>
                       </td>
                       <td className="p-2">
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
-                          {ALLERGEN_KEYS.map(({ key, icon }) => (
-                            <label
-                              key={key}
-                              className="flex items-center gap-1 border border-gray-300 dark:border-gray-700 rounded p-1"
-                            >
-                              <input
-                                type="checkbox"
-                                name={key}
-                                checked={!!editForm[key]}
-                                onChange={handleChange}
-                              />
-                              <span>{icon}</span>
-                              <span>{pictogramLabel(key)}</span>
-                            </label>
-                          ))}
-                        </div>
+                        <AllergenCheckboxes values={editForm} onChange={setEditForm} />
                         <label className="flex items-center text-xs mt-1">
                           <input
                             type="checkbox"
@@ -445,17 +427,19 @@ export default function UserManager() {
                       <td className="p-2">{u.country}</td>
                       <td className="p-2">{u.language}</td>
                       <td className="p-2">
-                       <div className="flex flex-wrap gap-1">
-                          {ALLERGEN_KEYS.filter(({ key }) => u[key]).map(({ key, icon }) => (
-                            <div
-                              key={key}
-                              className="w-8 h-8 flex flex-col items-center justify-center text-xs font-semibold border border-gray-400 dark:border-gray-600 rounded-md"
-                              title={pictogramLabel(key)}
-                            >
-                              <span className="text-base leading-none">{icon}</span>
-                              <span className="leading-none">{key}</span>
-                            </div>
-                          ))}
+                        <div className="flex flex-wrap gap-1">
+                          {metaPictograms
+                            .filter(({ key }) => u[key])
+                            .map(({ key, icon, tKey }) => (
+                              <div
+                                key={key}
+                                className="w-8 h-8 flex flex-col items-center justify-center text-xs font-semibold border border-gray-400 dark:border-gray-600 rounded-md"
+                                title={t(tKey)}
+                              >
+                                <span className="text-base leading-none">{icon}</span>
+                                <span className="leading-none">{key}</span>
+                              </div>
+                            ))}
                         </div>
                         {u.Diabetic && (
                           <div className="text-xs text-red-600 dark:text-red-400 mt-1">

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,9 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import './shared/i18n.js' 
 import App from './App.jsx'
+import { MetaProvider } from './shared/metaContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <MetaProvider>
+      <App />
+    </MetaProvider>
   </StrictMode>,
 )

--- a/frontend/src/shared/metaContext.jsx
+++ b/frontend/src/shared/metaContext.jsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { fetchJsonAuth } from "./config";
+import metaDefaults from "../../../shared/constants/meta.js";
+
+const DEFAULT_STATE = {
+  loading: true,
+  error: null,
+  version: metaDefaults?.VERSION || null,
+  pictograms: metaDefaults?.PICTOGRAMS || [],
+  allergens: metaDefaults?.ALLERGENS || [],
+  additives: metaDefaults?.ADDITIVES || [],
+};
+
+const MetaContext = createContext(DEFAULT_STATE);
+
+export function MetaProvider({ children }) {
+  const [state, setState] = useState(DEFAULT_STATE);
+
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      try {
+        const data = await fetchJsonAuth("/api/meta/init");
+        if (!alive) return;
+        setState({
+          loading: false,
+          error: null,
+          version: data?.version || metaDefaults?.VERSION || null,
+          pictograms: Array.isArray(data?.pictograms) ? data.pictograms : metaDefaults?.PICTOGRAMS || [],
+          allergens: Array.isArray(data?.allergens) ? data.allergens : metaDefaults?.ALLERGENS || [],
+          additives: Array.isArray(data?.additives) ? data.additives : metaDefaults?.ADDITIVES || [],
+        });
+      } catch (err) {
+        if (!alive) return;
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const value = useMemo(() => state, [state]);
+
+  return <MetaContext.Provider value={value}>{children}</MetaContext.Provider>;
+}
+
+export function useMeta() {
+  return useContext(MetaContext);
+}

--- a/shared/constants/meta.js
+++ b/shared/constants/meta.js
@@ -1,0 +1,49 @@
+const PICTOGRAMS = [
+  { key: "R", icon: "🥩", tKey: "Meals.Legend.Pictograms.R", allergenFamily: [] },
+  { key: "S", icon: "🐷", tKey: "Meals.Legend.Pictograms.S", allergenFamily: [] },
+  { key: "G", icon: "🐔", tKey: "Meals.Legend.Pictograms.G", allergenFamily: [] },
+  { key: "M", icon: "🥛", tKey: "Meals.Legend.Pictograms.M", allergenFamily: ["G"] },
+  { key: "A", icon: "🍷", tKey: "Meals.Legend.Pictograms.A", allergenFamily: [] },
+  {
+    key: "W",
+    icon: "🌾",
+    tKey: "Meals.Legend.Pictograms.W",
+    allergenFamily: ["A1", "A2", "A3", "A4", "A5", "A6", "A7"],
+  },
+  { key: "K", icon: "🧄", tKey: "Meals.Legend.Pictograms.K", allergenFamily: [] },
+  { key: "Y", icon: "🌱", tKey: "Meals.Legend.Pictograms.Y", allergenFamily: [] },
+];
+
+const ALLERGENS = [
+  { code: "A1", tKey: "Meals.Legend.Allergens.A1", family: "gluten" },
+  { code: "A2", tKey: "Meals.Legend.Allergens.A2", family: "gluten" },
+  { code: "A3", tKey: "Meals.Legend.Allergens.A3", family: "gluten" },
+  { code: "A4", tKey: "Meals.Legend.Allergens.A4", family: "gluten" },
+  { code: "A5", tKey: "Meals.Legend.Allergens.A5", family: "gluten" },
+  { code: "A6", tKey: "Meals.Legend.Allergens.A6", family: "gluten" },
+  { code: "A7", tKey: "Meals.Legend.Allergens.A7", family: "gluten" },
+  { code: "C", tKey: "Meals.Legend.Allergens.C", family: "egg" },
+  { code: "G", tKey: "Meals.Legend.Allergens.G", family: "milk" },
+  { code: "L", tKey: "Meals.Legend.Allergens.L", family: "celery" },
+];
+
+const ADDITIVES = [
+  { code: "1", tKey: "Meals.Legend.Additives.1" },
+  { code: "2", tKey: "Meals.Legend.Additives.2" },
+  { code: "3", tKey: "Meals.Legend.Additives.3" },
+  { code: "4", tKey: "Meals.Legend.Additives.4" },
+  { code: "5", tKey: "Meals.Legend.Additives.5" },
+  { code: "6", tKey: "Meals.Legend.Additives.6" },
+  { code: "7", tKey: "Meals.Legend.Additives.7" },
+];
+
+const VERSION = "2025.10.24";
+
+module.exports = {
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+  VERSION,
+};
+
+module.exports.default = module.exports;

--- a/shared/utils/derivePictograms.js
+++ b/shared/utils/derivePictograms.js
@@ -1,0 +1,21 @@
+function derivePictogramsFromAllergens(allergens = [], pictograms = []) {
+  if (!Array.isArray(allergens) || !allergens.length) return [];
+
+  const allergenSet = new Set(allergens.map(String));
+  const derived = new Set();
+
+  pictograms.forEach((pictogram) => {
+    const family = Array.isArray(pictogram?.allergenFamily)
+      ? pictogram.allergenFamily
+      : [];
+
+    if (family.some((code) => allergenSet.has(String(code)))) {
+      derived.add(pictogram.key);
+    }
+  });
+
+  return Array.from(derived);
+}
+
+module.exports = { derivePictogramsFromAllergens };
+module.exports.default = module.exports;


### PR DESCRIPTION
## Summary
- add shared meta definitions for pictograms, allergens, and additives alongside a helper to derive pictograms from allergen codes
- refactor food model and admin API endpoints to use the shared metadata, array storage, and a new /api/meta/init endpoint
- introduce a meta context, reusable allergen checkbox component, and update admin/settings UIs to consume the unified metadata

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68faf699a8a88322a2e6ed4b35462460