### PR TITLE
Refactor allergen metadata to shared constants

### DIFF
--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -38,6 +38,7 @@ const reminderRoute      = require('../routes/reminders');
 const roomsRoute         = require('../routes/rooms');
 const ttsRoute           = require('../routes/tts');
 const authRoute          = require('../routes/auth');
+const metaRoute          = require('../routes/meta');
 const adminUsersRoute    = require("../routes/admin/users");
 const adminFoodsRoute = require("../routes/admin/foods");
 //const adminMealsRoute    = require("../routes/admin/meals");
@@ -149,6 +150,7 @@ app.use('/exercises',     exercisesRoute);
 app.use('/reminders',     reminderRoute);
 app.use('/rooms',         roomsRoute);
 app.use('/tts',           ttsRoute);
+app.use('/api/meta',      metaRoute);
 app.use("/admin/users", adminUsersRoute);
 app.use("/admin/foods", adminFoodsRoute);
 

--- a/backend/models/food.js
+++ b/backend/models/food.js
@@ -1,5 +1,29 @@
 // backend/models/food.js
 const mongoose = require("mongoose");
+const {
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+} = require("../../shared/constants/meta");
+const { derivePictogramsFromAllergens } = require("../../shared/utils/derivePictograms");
+
+const VALID_PICTOGRAMS = new Set(PICTOGRAMS.map((p) => p.key));
+const VALID_ALLERGENS = new Set(ALLERGENS.map((a) => a.code));
+const VALID_ADDITIVES = new Set(ADDITIVES.map((a) => a.code));
+
+function sanitizeList(values, validSet) {
+  if (!Array.isArray(values)) return [];
+  const result = [];
+  values.forEach((value) => {
+    if (value == null) return;
+    const normalized = typeof value === "string" ? value : String(value);
+    const trimmed = normalized.trim();
+    if (trimmed && validSet.has(trimmed) && !result.includes(trimmed)) {
+      result.push(trimmed);
+    }
+  });
+  return result;
+}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Sub-schema for multilingual text
@@ -37,22 +61,32 @@ const foodSchema = new mongoose.Schema(
       default: {}, // e.g. { en: { dish, desc, category }, de: {...} }
     },
 
-    additives: [String],
-    allergens: [String],
-    pictograms: [String],
-    diabeticFriendly: { type: Boolean, required: true },
-
-    contains_R: Boolean,
-    contains_S: Boolean,
-    contains_G: Boolean,
-    contains_M: Boolean,
-    contains_A: Boolean,
-    contains_W: Boolean,
-    contains_K: Boolean,
-    contains_Y: Boolean,
+    additives: {
+      type: [String],
+      default: [],
+      set: (values) => sanitizeList(values, VALID_ADDITIVES),
+    },
+    allergens: {
+      type: [String],
+      default: [],
+      set: (values) => sanitizeList(values, VALID_ALLERGENS),
+    },
+    pictograms: {
+      type: [String],
+      default: [],
+      set: (values) => sanitizeList(values, VALID_PICTOGRAMS),
+    },
+    diabeticFriendly: { type: Boolean, required: true, default: false },
   },
   { timestamps: true }
 );
+
+foodSchema.set("toJSON", { virtuals: true });
+foodSchema.set("toObject", { virtuals: true });
+
+foodSchema.virtual("derivedPictograms").get(function derived() {
+  return derivePictogramsFromAllergens(this.allergens || [], PICTOGRAMS);
+});
 
 // Indexes
 foodSchema.index({ barcode: 1 });

--- a/backend/routes/admin/foods.js
+++ b/backend/routes/admin/foods.js
@@ -6,6 +6,16 @@ const mongoose = require("mongoose");
 const router = express.Router();
 const Food = require("../../models/food");
 const isAdmin = require("../../middleware/isAdmin");
+const {
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+} = require("../../../shared/constants/meta");
+const { derivePictogramsFromAllergens } = require("../../../shared/utils/derivePictograms");
+
+const VALID_PICTOGRAMS = new Set(PICTOGRAMS.map((p) => p.key));
+const VALID_ALLERGENS = new Set(ALLERGENS.map((a) => a.code));
+const VALID_ADDITIVES = new Set(ADDITIVES.map((a) => a.code));
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Admin guard
@@ -47,6 +57,32 @@ function parseBool(v) {
   return false;
 }
 
+function sanitizeCodes(values, validSet) {
+  if (!Array.isArray(values)) return [];
+  const result = [];
+  values.forEach((value) => {
+    if (value == null) return;
+    const normalized = typeof value === "string" ? value : String(value);
+    const trimmed = normalized.trim();
+    if (trimmed && validSet.has(trimmed) && !result.includes(trimmed)) {
+      result.push(trimmed);
+    }
+  });
+  return result;
+}
+
+function legacyPictogramFlags(source) {
+  if (!source) return [];
+  const keys = [];
+  PICTOGRAMS.forEach(({ key }) => {
+    const flagKey = `contains_${key}`;
+    if (flagKey in source && parseBool(source[flagKey])) {
+      keys.push(key);
+    }
+  });
+  return keys;
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Multer memory storage
 // ──────────────────────────────────────────────────────────────────────────────
@@ -68,7 +104,7 @@ router.get("/", async (req, res) => {
         { barcode: rx },
       ];
     }
-    const foods = await Food.find(filter).sort({ id: -1 }).lean();
+    const foods = await Food.find(filter).sort({ id: -1 }).lean({ virtuals: true });
     foods.forEach((f) => delete f.image);
     res.json(foods);
   } catch (e) {
@@ -102,25 +138,7 @@ router.get("/:id/image", async (req, res) => {
 // ──────────────────────────────────────────────────────────────────────────────
 router.post("/", upload.single("image"), async (req, res) => {
   try {
-    const {
-      barcode,
-      date,
-      category,
-      dish,
-      description,
-      additives,
-      allergens,
-      pictograms,
-      diabeticFriendly,
-      contains_R,
-      contains_S,
-      contains_G,
-      contains_M,
-      contains_A,
-      contains_W,
-      contains_K,
-      contains_Y,
-    } = req.body;
+    const { barcode, date, category, dish, description, diabeticFriendly } = req.body;
 
     if (!barcode || !date || !category || !dish || typeof diabeticFriendly === "undefined") {
       return res.status(400).json({
@@ -133,11 +151,20 @@ router.post("/", upload.single("image"), async (req, res) => {
     try {
       if (req.body.translations) {
         const parsed = JSON.parse(req.body.translations);
-        if (typeof parsed === "object") translations = parsed;
+        if (parsed && typeof parsed === "object") translations = parsed;
       }
     } catch (e) {
       console.warn("Invalid translations JSON:", e);
     }
+
+    const providedAllergens = sanitizeCodes(parseArray(req.body.allergens), VALID_ALLERGENS);
+    const providedAdditives = sanitizeCodes(parseArray(req.body.additives), VALID_ADDITIVES);
+    const providedPictograms = sanitizeCodes(parseArray(req.body.pictograms), VALID_PICTOGRAMS);
+    const legacyFlags = legacyPictogramFlags(req.body);
+    const derivedFromAllergens = derivePictogramsFromAllergens(providedAllergens, PICTOGRAMS);
+    const allPictograms = Array.from(
+      new Set([...providedPictograms, ...legacyFlags, ...derivedFromAllergens])
+    );
 
     // Auto-generate next numeric id
     const lastFood = await Food.findOne().sort({ id: -1 }).lean();
@@ -151,19 +178,10 @@ router.post("/", upload.single("image"), async (req, res) => {
       dish: String(dish),
       description: description ?? null,
       translations,
-      additives: parseArray(additives),
-      allergens: parseArray(allergens),
-      pictograms: parseArray(pictograms),
+      additives: providedAdditives,
+      allergens: providedAllergens,
+      pictograms: allPictograms,
       diabeticFriendly: parseBool(diabeticFriendly),
-
-      contains_R: parseBool(contains_R),
-      contains_S: parseBool(contains_S),
-      contains_G: parseBool(contains_G),
-      contains_M: parseBool(contains_M),
-      contains_A: parseBool(contains_A),
-      contains_W: parseBool(contains_W),
-      contains_K: parseBool(contains_K),
-      contains_Y: parseBool(contains_Y),
     });
 
     if (req.file) {
@@ -201,22 +219,41 @@ router.put("/:id", upload.single("image"), async (req, res) => {
 
     if (body.diabeticFriendly != null)
       body.diabeticFriendly = parseBool(body.diabeticFriendly);
-    if (body.additives != null) body.additives = parseArray(body.additives);
-    if (body.allergens != null) body.allergens = parseArray(body.allergens);
-    if (body.pictograms != null) body.pictograms = parseArray(body.pictograms);
-    const bools = [
-      "contains_R",
-      "contains_S",
-      "contains_G",
-      "contains_M",
-      "contains_A",
-      "contains_W",
-      "contains_K",
-      "contains_Y",
-    ];
-    for (const k of bools) {
-      if (k in body) body[k] = parseBool(body[k]);
+
+    let pictogramSet = null;
+
+    if (body.additives != null)
+      body.additives = sanitizeCodes(parseArray(body.additives), VALID_ADDITIVES);
+    if (body.allergens != null) {
+      body.allergens = sanitizeCodes(parseArray(body.allergens), VALID_ALLERGENS);
+      if (body.allergens.length) {
+        pictogramSet = pictogramSet || new Set();
+        derivePictogramsFromAllergens(body.allergens, PICTOGRAMS).forEach((key) =>
+          pictogramSet.add(key)
+        );
+      }
     }
+    if (body.pictograms != null) {
+      const provided = sanitizeCodes(parseArray(body.pictograms), VALID_PICTOGRAMS);
+      pictogramSet = pictogramSet || new Set();
+      provided.forEach((key) => pictogramSet.add(key));
+    }
+
+    const legacy = legacyPictogramFlags(body);
+    if (legacy.length) {
+      pictogramSet = pictogramSet || new Set();
+      legacy.forEach((key) => pictogramSet.add(key));
+    }
+
+    if (pictogramSet !== null) {
+      body.pictograms = Array.from(pictogramSet);
+    }
+
+    // Remove legacy flag keys to avoid storing stale data
+    PICTOGRAMS.forEach(({ key }) => {
+      const flagKey = `contains_${key}`;
+      if (flagKey in body) delete body[flagKey];
+    });
 
     if (req.file) {
       body.image = {

--- a/backend/routes/foods.js
+++ b/backend/routes/foods.js
@@ -22,7 +22,7 @@ function safeFoodQuery(idOrString) {
  */
 router.get("/", async (_req, res) => {
   try {
-    const foods = await Food.find().sort({ createdAt: -1 }).lean();
+    const foods = await Food.find().sort({ createdAt: -1 }).lean({ virtuals: true });
     // Hide binary data to avoid sending megabytes
     foods.forEach(f => delete f.image);
     res.json(foods);
@@ -37,7 +37,7 @@ router.get("/", async (_req, res) => {
  */
 router.get("/:barcode", async (req, res) => {
   try {
-    const food = await Food.findOne({ barcode: req.params.barcode }).lean();
+    const food = await Food.findOne({ barcode: req.params.barcode }).lean({ virtuals: true });
     if (!food) return res.status(404).json({ message: "Not found" });
     delete food.image; // remove heavy blob
     res.json(food);

--- a/backend/routes/meta.js
+++ b/backend/routes/meta.js
@@ -1,0 +1,20 @@
+const express = require("express");
+const router = express.Router();
+
+const {
+  VERSION,
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+} = require("../../shared/constants/meta");
+
+router.get("/init", (_req, res) => {
+  res.json({
+    version: VERSION,
+    pictograms: PICTOGRAMS,
+    allergens: ALLERGENS,
+    additives: ADDITIVES,
+  });
+});
+
+module.exports = router;

--- a/frontend/src/components/AllergenCheckboxes.jsx
+++ b/frontend/src/components/AllergenCheckboxes.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useMeta } from "../shared/meta";
+
+export default function AllergenCheckboxes({ values, onChange, prefix = "", readOnly = false }) {
+  const { t } = useTranslation();
+  const { pictograms } = useMeta();
+
+  const handleToggle = (key) => {
+    if (readOnly) return;
+    const field = prefix ? `${prefix}${key}` : key;
+    const current = !!values?.[field];
+    const nextValues = { ...(values || {}) };
+    nextValues[field] = !current;
+    onChange?.(nextValues);
+  };
+
+  if (!Array.isArray(pictograms) || pictograms.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+      {pictograms.map(({ key, icon, tKey }) => {
+        const field = prefix ? `${prefix}${key}` : key;
+        const checked = !!values?.[field];
+        return (
+          <label
+            key={key}
+            className="flex items-center gap-1 border border-gray-300 dark:border-gray-700 rounded p-1"
+          >
+            <input
+              type="checkbox"
+              checked={checked}
+              onChange={() => handleToggle(key)}
+              disabled={readOnly}
+            />
+            <span>{icon || key}</span>
+            <span>{t(tKey, key)}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import logo from "../resources/Logo_Gold_Blau_Rubik.png";
 import { Link } from "react-router-dom";
-import SettingsModal from "../features/SettingsModal";
+import SettingsModal from "./SettingsModal.jsx";
 import Calendar from "../features/Calendar";
 import { AppContext } from "../shared/AppContext";
 import { useTranslation } from "react-i18next";

--- a/frontend/src/components/SettingsModal.jsx
+++ b/frontend/src/components/SettingsModal.jsx
@@ -1,0 +1,372 @@
+// frontend/src/components/SettingsModal.jsx
+import React, { useEffect, useState, useContext, useMemo } from "react";
+import {
+  FaVolumeMute,
+  FaVolumeUp,
+  FaRunning,
+  FaTachometerAlt,
+  FaUserShield,
+} from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { AppContext } from "../shared/AppContext";
+import { API } from "../shared/config";
+import AllergenCheckboxes from "./AllergenCheckboxes.jsx";
+import { useMeta } from "../shared/meta";
+
+export default function SettingsModal({ onClose }) {
+  const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
+  const { user, setUser, darkMode, setDarkMode } = useContext(AppContext);
+  const { pictograms: metaPictograms } = useMeta();
+
+  const [scale, setScale] = useState(parseFloat(localStorage.getItem("fontScale")) || 1);
+  const [activeTab, setActiveTab] = useState("general");
+  const [saveStatus, setSaveStatus] = useState(null);
+  const [languageSaving, setLanguageSaving] = useState(false);
+  const [languageError, setLanguageError] = useState(null);
+
+  /** ─────────────────────────── Health flags ─────────────────────────── **/
+  const pictogramDefaults = useMemo(() => {
+    const defaults = {};
+    (metaPictograms || []).forEach(({ key }) => {
+      defaults[key] = false;
+    });
+    return defaults;
+  }, [metaPictograms]);
+
+  const [healthFlags, setHealthFlags] = useState(pictogramDefaults);
+  const [diabetic, setDiabetic] = useState(!!user?.Diabetic);
+
+  useEffect(() => {
+    const nextFlags = (metaPictograms || []).reduce(
+      (acc, { key }) => ({ ...acc, [key]: !!user?.[key] }),
+      { ...pictogramDefaults }
+    );
+    setHealthFlags(nextFlags);
+    setDiabetic(!!user?.Diabetic);
+  }, [user, pictogramDefaults, metaPictograms]);
+
+  /** ─────────────────────────── Language logic ─────────────────────────── **/
+  const LANGUAGE_LABELS = useMemo(
+    () => ({
+      en: "English",
+      he: "עברית",
+      de: "Deutsch",
+      fi: "Suomi",
+    }),
+    []
+  );
+
+  const availableLanguages = useMemo(() => {
+    if (user?.languages?.length) {
+      const seen = new Set();
+      return user.languages.filter((code) => {
+        if (!code || seen.has(code)) return false;
+        seen.add(code);
+        return true;
+      });
+    }
+    return Object.keys(LANGUAGE_LABELS);
+  }, [LANGUAGE_LABELS, user]);
+
+  const languageLabel = (code) => LANGUAGE_LABELS[code] || code;
+
+  /** ─────────────────────────── Font scale ─────────────────────────── **/
+  useEffect(() => {
+    document.documentElement.style.fontSize = `${16 * scale}px`;
+    localStorage.setItem("fontScale", scale);
+  }, [scale]);
+
+  /** ─────────────────────────── Language change ─────────────────────────── **/
+  const changeLanguage = async (lng) => {
+    if (!lng || lng === i18n.language) return;
+    setLanguageError(null);
+    const prev = i18n.language;
+    let resetSpinner = false;
+
+    try {
+      await i18n.changeLanguage(lng);
+      localStorage.setItem("i18nextLng", lng);
+      if (!user?.id) return;
+
+      setLanguageSaving(true);
+      resetSpinner = true;
+      const res = await fetch(`${API}/users/${user.id}`, {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ language: lng }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.message || "Failed to update language");
+      }
+      const updated = await res.json();
+      setUser(updated);
+    } catch (err) {
+      console.error("Failed to change language", err);
+      setLanguageError(err?.message || "Failed to update language");
+      await i18n.changeLanguage(prev).catch(() => {});
+      localStorage.setItem("i18nextLng", prev);
+    } finally {
+      if (resetSpinner) setLanguageSaving(false);
+    }
+  };
+
+  /** ─────────────────────────── Health toggle/save ─────────────────────────── **/
+  const saveHealth = async () => {
+    if (!user) return;
+    try {
+      const payload = { ...healthFlags, Diabetic: diabetic };
+      const res = await fetch(`${API}/users/${user.id}/health`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(payload),
+      });
+
+      if (res.ok) {
+        const updated = await res.json();
+        setUser(updated);
+        setSaveStatus("success");
+      } else {
+        setSaveStatus("error");
+      }
+      setTimeout(() => setSaveStatus(null), 3000);
+    } catch (err) {
+      console.error("Error saving health info", err);
+      setSaveStatus("error");
+    }
+  };
+
+  /** ─────────────────────────── Logout ─────────────────────────── **/
+  const logout = async () => {
+    try {
+      await fetch(`${API}/auth/logout`, { method: "POST", credentials: "include" });
+    } catch {}
+    setUser(null);
+    onClose?.();
+  };
+
+  /** ─────────────────────────── UI ─────────────────────────── **/
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="w-[90%] max-w-4xl max-h-[90vh] overflow-y-auto bg-white dark:bg-gray-800 rounded-3xl shadow-xl p-6 relative flex flex-col md:flex-row">
+        {/* Sidebar */}
+        <div className="w-full md:w-32 md:pr-4 border-b md:border-b-0 md:border-r border-gray-300 dark:border-gray-600 shrink-0">
+          <h2 className="text-3xl font-bold text-blue-800 dark:text-blue-200 mb-6">
+            {t("SettingsModal.title")}
+          </h2>
+          <nav className="flex md:flex-col flex-row gap-2 justify-center">
+            <button
+              onClick={() => setActiveTab("general")}
+              className={`px-3 py-2 rounded ${
+                activeTab === "general"
+                  ? "bg-blue-600 text-white"
+                  : "bg-gray-200 dark:bg-gray-700"
+              }`}
+            >
+              {t("SettingsModal.general")}
+            </button>
+            <button
+              onClick={() => setActiveTab("health")}
+              className={`px-3 py-2 rounded ${
+                activeTab === "health"
+                  ? "bg-blue-600 text-white"
+                  : "bg-gray-200 dark:bg-gray-700"
+              }`}
+            >
+              {t("SettingsModal.health")}
+            </button>
+            {user?.isAdmin && (
+              <button
+                onClick={() => {
+                  onClose?.();
+                  navigate("/admin");
+                }}
+                className="px-3 py-2 rounded bg-yellow-500 hover:bg-yellow-400 text-white flex items-center justify-center gap-2"
+              >
+                <FaUserShield /> {t("SettingsModal.admin", "Admin")}
+              </button>
+            )}
+          </nav>
+        </div>
+
+        {/* Main content */}
+        <div className="flex-1 md:pl-6 overflow-y-auto">
+          {/* ─────────── GENERAL TAB ─────────── */}
+          {activeTab === "general" && (
+            <>
+              {/* TEXT SIZE */}
+              <section className="mb-8">
+                <h3 className="text-xl font-semibold mb-3">
+                  {t("SettingsModal.textSize")}
+                </h3>
+                <div className="flex items-center gap-4">
+                  <span className="text-3xl font-bold">A</span>
+                  <input
+                    type="range"
+                    min={0.8}
+                    max={1.6}
+                    step={0.05}
+                    value={scale}
+                    onChange={(e) => setScale(parseFloat(e.target.value))}
+                    className="flex-1 accent-blue-600 h-2 rounded-lg bg-gray-300"
+                  />
+                  <span className="text-5xl font-bold">A</span>
+                </div>
+              </section>
+
+              {/* VOLUME (placeholder) */}
+              <section className="mb-8">
+                <h3 className="text-xl font-semibold mb-3">
+                  {t("SettingsModal.volume")}
+                </h3>
+                <div className="flex items-center gap-4">
+                  <FaVolumeMute className="text-2xl" />
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    defaultValue={70}
+                    className="flex-1 accent-blue-600 h-2 rounded-lg bg-gray-300"
+                    disabled
+                  />
+                  <FaVolumeUp className="text-2xl" />
+                </div>
+              </section>
+
+              {/* SPEAKING SPEED (placeholder) */}
+              <section className="mb-8">
+                <h3 className="text-xl font-semibold mb-3">
+                  {t("SettingsModal.speakingSpeed")}
+                </h3>
+                <div className="flex items-center gap-4">
+                  <FaTachometerAlt className="text-2xl" />
+                  <input
+                    type="range"
+                    min={0.5}
+                    max={1.5}
+                    step={0.1}
+                    defaultValue={1}
+                    className="flex-1 accent-blue-600 h-2 rounded-lg bg-gray-300"
+                    disabled
+                  />
+                  <FaRunning className="text-2xl" />
+                </div>
+              </section>
+
+              {/* LANGUAGE */}
+              <section className="mb-8">
+                <h3 className="text-xl font-semibold mb-2">
+                  {t("SettingsModal.language")}
+                </h3>
+                <select
+                  value={i18n.language}
+                  onChange={(e) => changeLanguage(e.target.value)}
+                  className="border rounded px-2 py-1 border-teal-400 dark:bg-blue-900 dark:hover:bg-blue-800"
+                  disabled={languageSaving}
+                >
+                  {availableLanguages.map((code) => (
+                    <option key={code} value={code}>
+                      {languageLabel(code)}
+                    </option>
+                  ))}
+                </select>
+                {languageError && (
+                  <p className="mt-2 text-sm text-red-600">{languageError}</p>
+                )}
+              </section>
+
+              {/* DARK MODE */}
+              <section className="mb-8">
+                <h3 className="text-xl font-semibold mb-3">
+                  {t("SettingsModal.darkMode")}
+                </h3>
+                <label className="relative inline-block w-14 h-8 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="peer sr-only"
+                    checked={darkMode}
+                    onChange={(e) => setDarkMode(e.target.checked)}
+                  />
+                  <div className="absolute inset-0 bg-gray-200 peer-checked:bg-blue-600 rounded-full transition-colors duration-300"></div>
+                  <div className="absolute top-1 left-1 w-6 h-6 bg-white rounded-full shadow transform transition-transform duration-300 peer-checked:translate-x-[26px]"></div>
+                  <div className="absolute top-1 left-1 text-xl transition-opacity duration-300 peer-checked:opacity-0">🌞</div>
+                  <div className="absolute top-1 left-[26px] text-xl transition-opacity duration-300 opacity-0 peer-checked:opacity-100">🌙</div>
+                </label>
+              </section>
+
+              <div className="flex flex-col md:flex-row justify-between mt-4 gap-2">
+                <button
+                  onClick={onClose}
+                  className="bg-gray-400 hover:bg-gray-300 dark:bg-teal-700 dark:hover:bg-teal-600 px-4 py-2 rounded text-white"
+                >
+                  {t("SettingsModal.close")}
+                </button>
+                <button
+                  onClick={logout}
+                  className="bg-red-600 hover:bg-red-500 text-white px-4 py-2 rounded"
+                >
+                  Logout
+                </button>
+              </div>
+            </>
+          )}
+
+          {/* ─────────── HEALTH TAB ─────────── */}
+          {activeTab === "health" && (
+            <section className="mb-6">
+              <h3 className="text-xl font-semibold mb-3">
+                {t("SettingsModal.health")}
+              </h3>
+
+              <AllergenCheckboxes values={healthFlags} onChange={setHealthFlags} />
+
+              <label className="flex items-center gap-2 block mt-2">
+                <input
+                  type="checkbox"
+                  checked={diabetic}
+                  onChange={(e) => setDiabetic(e.target.checked)}
+                />
+                {t("SettingsModal.diabetic")}
+              </label>
+
+              {saveStatus === "success" && (
+                <p className="mt-2 text-black">{t("SettingsModal.saveSuccess")}</p>
+              )}
+              {saveStatus === "error" && (
+                <p className="mt-2 text-black">{t("SettingsModal.saveError")}</p>
+              )}
+
+              <div className="flex flex-col md:flex-row justify-between mt-4 gap-2">
+                <button
+                  onClick={onClose}
+                  className="bg-gray-400 hover:bg-gray-300 dark:bg-teal-700 dark:hover:bg-teal-600 px-4 py-2 rounded text-white"
+                >
+                  {t("SettingsModal.close")}
+                </button>
+                <button
+                  onClick={saveHealth}
+                  className="bg-blue-600 hover:bg-blue-500 dark:bg-blue-800 dark:hover:bg-blue-700 text-white px-4 py-2 rounded"
+                >
+                  {t("SettingsModal.save")}
+                </button>
+              </div>
+
+              <div className="mt-4 flex justify-end">
+                <button
+                  onClick={logout}
+                  className="bg-red-600 hover:bg-red-500 text-white px-4 py-2 rounded"
+                >
+                  Logout
+                </button>
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/AddFoodModal.jsx
+++ b/frontend/src/features/admin/AddFoodModal.jsx
@@ -2,43 +2,47 @@ import React, { useEffect, useMemo, useState } from "react";
 import { API } from "../../shared/config";
 import { useTranslation } from "react-i18next";
 import { LANG_LABELS } from "../../shared/constants";
-
-const ALLERGEN_KEYS = [
-  { key: "R", icon: "🥩" },
-  { key: "S", icon: "🐷" },
-  { key: "G", icon: "🐔" },
-  { key: "M", icon: "🥛" },
-  { key: "A", icon: "🍷" },
-  { key: "W", icon: "🌾" },
-  { key: "K", icon: "🧄" },
-  { key: "Y", icon: "🌱" },
-];
+import AllergenCheckboxes from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/meta";
 
 const SUPPORTED_LANGS = ["en", "de", "fi", "he"];
 const safeLangLabel = (lang, t) =>
   t(`Admin.Foods.languageTabs.${lang}`, LANG_LABELS?.[lang] || lang.toUpperCase());
 
+const createEmptyTranslations = () => ({
+  en: { dish: "", description: "", category: "" },
+  de: { dish: "", description: "", category: "" },
+  fi: { dish: "", description: "", category: "" },
+  he: { dish: "", description: "", category: "" },
+});
+
 export default function AddFoodModal({ onClose, onAdded }) {
   const { t } = useTranslation();
+  const { pictograms: metaPictograms } = useMeta();
   const [activeLang, setActiveLang] = useState("en");
   const [file, setFile] = useState(null);
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState(null);
 
+  const pictogramDefaults = useMemo(() => {
+    const defaults = {};
+    (metaPictograms || []).forEach(({ key }) => {
+      defaults[key] = false;
+    });
+    return defaults;
+  }, [metaPictograms]);
+
   const [form, setForm] = useState({
     barcode: "",
     date: new Date().toISOString().slice(0, 10),
     diabeticFriendly: false,
-    // pictogram flags
-    R: false, S: false, G: false, M: false, A: false, W: false, K: false, Y: false,
-    // multilingual content
-    translations: {
-      en: { dish: "", description: "", category: "" },
-      de: { dish: "", description: "", category: "" },
-      fi: { dish: "", description: "", category: "" },
-      he: { dish: "", description: "", category: "" },
-    },
+    ...pictogramDefaults,
+    translations: createEmptyTranslations(),
   });
+
+  useEffect(() => {
+    setForm((prev) => ({ ...pictogramDefaults, ...prev }));
+  }, [pictogramDefaults]);
 
   // ────────────────────────────────
   //  Helpers
@@ -90,8 +94,10 @@ export default function AddFoodModal({ onClose, onAdded }) {
       fd.append("category", en.category);
       fd.append("description", en.description || "");
 
-      // pictograms (booleans)
-      ALLERGEN_KEYS.forEach(({ key }) => fd.append(`contains_${key}`, String(!!form[key])));
+      const selectedPictograms = (metaPictograms || [])
+        .filter(({ key }) => form[key])
+        .map(({ key }) => key);
+      fd.append("pictograms", JSON.stringify(selectedPictograms));
 
       // full multilingual payload
       fd.append("translations", JSON.stringify(form.translations));
@@ -172,25 +178,7 @@ export default function AddFoodModal({ onClose, onAdded }) {
             <p className="font-semibold mb-2">
               {t("Meals.LegendHeadings.Pictograms", "Pictograms")}
             </p>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm">
-              {ALLERGEN_KEYS.map(({ key, icon }) => (
-                <label
-                  key={key}
-                  className="flex items-center gap-2 border border-gray-300 dark:border-gray-700 rounded p-2"
-                >
-                  <input
-                    type="checkbox"
-                    checked={!!form[key]}
-                    onChange={(e) => setForm({ ...form, [key]: e.target.checked })}
-                  />
-                  <span className="text-base">{icon}</span>
-                  <span>
-                    {t(`Meals.Legend.Pictograms.${key}`, key)}
-                    {" (" + key + ")"}
-                  </span>
-                </label>
-              ))}
-            </div>
+            <AllergenCheckboxes values={form} onChange={setForm} readOnly={loading} />
           </div>
 
           {/* Language Tabs */}

--- a/frontend/src/features/admin/AddUserModal.jsx
+++ b/frontend/src/features/admin/AddUserModal.jsx
@@ -1,22 +1,21 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { API } from "../../shared/config";
 import { COUNTRIES, AVAILABLE_LANGUAGES, LANG_LABELS } from "../../shared/constants";
+import AllergenCheckboxes from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/meta";
 
 export default function AddUserModal({ open, onClose, onAdded }) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
 
-  // Same pictogram keys used in UserManager
-  const ALLERGEN_KEYS = [
-    { key: "R", icon: "🥩" },
-    { key: "S", icon: "🐷" },
-    { key: "G", icon: "🐔" },
-    { key: "M", icon: "🥛" },
-    { key: "A", icon: "🍷" },
-    { key: "W", icon: "🌾" },
-    { key: "K", icon: "🧄" },
-    { key: "Y", icon: "🌱" },
-  ];
+  const { pictograms: metaPictograms } = useMeta();
+  const pictogramDefaults = useMemo(() => {
+    const defaults = {};
+    (metaPictograms || []).forEach(({ key }) => {
+      defaults[key] = false;
+    });
+    return defaults;
+  }, [metaPictograms]);
 
   const [form, setForm] = useState({
     fullName: "",
@@ -27,11 +26,15 @@ export default function AddUserModal({ open, onClose, onAdded }) {
     phoneNumber: "",
     dateOfBirth: "",
     gender: "other",
-    R: false, S: false, G: false, M: false, A: false, W: false, K: false, Y: false,
+    ...pictogramDefaults,
     Diabetic: false,
     country: "",
     language: "",
   });
+
+  useEffect(() => {
+    setForm((prev) => ({ ...pictogramDefaults, ...prev }));
+  }, [pictogramDefaults]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -69,18 +72,14 @@ export default function AddUserModal({ open, onClose, onAdded }) {
         phoneNumber: form.phoneNumber.trim() || undefined,
         dateOfBirth: form.dateOfBirth ? new Date(form.dateOfBirth) : undefined,
         gender: form.gender,
-        R: !!form.R,
-        S: !!form.S,
-        G: !!form.G,
-        M: !!form.M,
-        A: !!form.A,
-        W: !!form.W,
-        K: !!form.K,
-        Y: !!form.Y,
         Diabetic: !!form.Diabetic,
         country: form.country,
         language: form.language,
       };
+
+      (metaPictograms || []).forEach(({ key }) => {
+        payload[key] = !!form[key];
+      });
 
       const res = await fetch(`${API}/admin/users/add`, {
         method: "POST",
@@ -102,7 +101,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
         phoneNumber: "",
         dateOfBirth: "",
         gender: "other",
-        R: false, S: false, G: false, M: false, A: false, W: false, K: false, Y: false,
+        ...pictogramDefaults,
         Diabetic: false,
         country: "",
         language: "",
@@ -198,22 +197,7 @@ export default function AddUserModal({ open, onClose, onAdded }) {
             <div className="text-sm font-semibold mb-1 text-gray-800 dark:text-gray-200">
               {t("Admin.Users.health", "Health Flags")}
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-              {ALLERGEN_KEYS.map(({ key, icon }) => (
-                <label key={key} className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    name={key}
-                    checked={!!form[key]}
-                    onChange={handleChange}
-                  />
-                  <span className="text-sm">
-                    {icon}{" "}
-                    {t(`Meals.Legend.Pictograms.${key}`, key)}
-                  </span>
-                </label>
-              ))}
-            </div>
+            <AllergenCheckboxes values={form} onChange={setForm} readOnly={loading} />
           </div>
 
           {/* Diabetic, Country, Language */}

--- a/frontend/src/features/admin/FoodManager.jsx
+++ b/frontend/src/features/admin/FoodManager.jsx
@@ -4,17 +4,8 @@ import { API } from "../../shared/config";
 import { useTranslation } from "react-i18next";
 import AddFoodModal from "./AddFoodModal";
 import { QRCodeCanvas } from "qrcode.react";
-
-const ALLERGEN_KEYS = [
-  { key: "R", icon: "🥩" },
-  { key: "S", icon: "🐷" },
-  { key: "G", icon: "🐔" },
-  { key: "M", icon: "🥛" },
-  { key: "A", icon: "🍷" },
-  { key: "W", icon: "🌾" },
-  { key: "K", icon: "🧄" },
-  { key: "Y", icon: "🌱" },
-];
+import AllergenCheckboxes from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/meta";
 const SUPPORTED_LANGS = ["en", "de", "fi", "he"];
 
 function getLocalized(food, lang) {
@@ -24,6 +15,7 @@ function getLocalized(food, lang) {
 
 export default function FoodManager() {
   const { t, i18n } = useTranslation();
+  const { pictograms: metaPictograms } = useMeta();
   const [foods, setFoods] = useState([]);
   const [query, setQuery] = useState("");
   const [addOpen, setAddOpen] = useState(false);
@@ -51,6 +43,23 @@ export default function FoodManager() {
     fetchFoods();
   }, []);
 
+  const pictogramMap = useMemo(() => {
+    return new Map((metaPictograms || []).map((p) => [p.key, p]));
+  }, [metaPictograms]);
+
+  const pictogramDefaults = useMemo(() => {
+    const defaults = {};
+    (metaPictograms || []).forEach(({ key }) => {
+      defaults[`contains_${key}`] = false;
+    });
+    return defaults;
+  }, [metaPictograms]);
+
+  useEffect(() => {
+    if (!editingId) return;
+    setEditForm((prev) => ({ ...pictogramDefaults, ...prev }));
+  }, [editingId, pictogramDefaults]);
+
   const filteredFoods = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return foods;
@@ -64,14 +73,20 @@ export default function FoodManager() {
 
   function startEdit(food) {
     setEditingId(food.id);
-    const b = {};
-    ALLERGEN_KEYS.forEach(({ key }) => (b[key] = !!food[`contains_${key}`] || !!food[key]));
+    const toggleValues = { ...pictogramDefaults };
+    (metaPictograms || []).forEach(({ key }) => {
+      const prefixKey = `contains_${key}`;
+      const hasLegacy = !!food[`contains_${key}`] || !!food[key];
+      const hasExplicit = Array.isArray(food?.pictograms) && food.pictograms.includes(key);
+      const hasDerived = Array.isArray(food?.derivedPictograms) && food.derivedPictograms.includes(key);
+      toggleValues[prefixKey] = hasLegacy || hasExplicit || hasDerived;
+    });
     setEditForm({
       id: food.id,
       barcode: food.barcode || "",
       date: (food.date || "").slice?.(0, 10) || "",
       diabeticFriendly: !!food.diabeticFriendly,
-      ...b,
+      ...toggleValues,
       translations: {
         en: { dish: "", description: "", category: "", ...(food.translations?.en || {}) },
         de: { dish: "", description: "", category: "", ...(food.translations?.de || {}) },
@@ -102,7 +117,10 @@ export default function FoodManager() {
       fd.append("barcode", editForm.barcode || "");
       if (editForm.date) fd.append("date", editForm.date);
       fd.append("diabeticFriendly", String(!!editForm.diabeticFriendly));
-      ALLERGEN_KEYS.forEach(({ key }) => fd.append(`contains_${key}`, String(!!editForm[key])));
+      const selectedPictograms = (metaPictograms || [])
+        .filter(({ key }) => editForm[`contains_${key}`])
+        .map(({ key }) => key);
+      fd.append("pictograms", JSON.stringify(selectedPictograms));
       fd.append("translations", JSON.stringify(editForm.translations));
       if (editFile) fd.append("image", editFile);
 
@@ -243,18 +261,25 @@ export default function FoodManager() {
                       </td>
                       <td className="p-2">
                         <div className="flex flex-wrap gap-1">
-                          {ALLERGEN_KEYS.filter(({ key }) => f[`contains_${key}`] || f[key]).map(
-                            ({ key, icon }) => (
-                              <div
-                                key={key}
-                                className="w-8 h-8 flex flex-col items-center justify-center text-xs font-semibold border border-gray-400 dark:border-gray-600 rounded-md"
-                                title={t(`Meals.Legend.Pictograms.${key}`, key)}
-                              >
-                                <span className="text-base leading-none">{icon}</span>
-                                <span className="leading-none">{key}</span>
-                              </div>
-                            )
-                          )}
+                          {(metaPictograms || [])
+                            .filter(({ key }) => {
+                              if (Array.isArray(f?.pictograms) && f.pictograms.includes(key)) return true;
+                              if (Array.isArray(f?.derivedPictograms) && f.derivedPictograms.includes(key)) return true;
+                              return !!f[`contains_${key}`] || !!f[key];
+                            })
+                            .map(({ key }) => {
+                              const meta = pictogramMap.get(key) || { icon: key, tKey: key };
+                              return (
+                                <div
+                                  key={key}
+                                  className="w-8 h-8 flex flex-col items-center justify-center text-xs font-semibold border border-gray-400 dark:border-gray-600 rounded-md"
+                                  title={t(meta.tKey, key)}
+                                >
+                                  <span className="text-base leading-none">{meta.icon || key}</span>
+                                  <span className="leading-none">{key}</span>
+                                </div>
+                              );
+                            })}
                         </div>
                       </td>
                       <td className="p-2 text-center whitespace-nowrap">
@@ -371,24 +396,11 @@ export default function FoodManager() {
                         </label>
                       </td>
                       <td className="p-2">
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
-                          {ALLERGEN_KEYS.map(({ key, icon }) => (
-                            <label
-                              key={key}
-                              className="flex items-center gap-1 border border-gray-300 dark:border-gray-700 rounded p-1"
-                            >
-                              <input
-                                type="checkbox"
-                                checked={!!editForm[key]}
-                                onChange={(e) =>
-                                  setEditForm((ef) => ({ ...ef, [key]: e.target.checked }))
-                                }
-                              />
-                              <span>{icon}</span>
-                              <span>{t(`Meals.Legend.Pictograms.${key}`, key)}</span>
-                            </label>
-                          ))}
-                        </div>
+                        <AllergenCheckboxes
+                          values={editForm}
+                          onChange={setEditForm}
+                          prefix="contains_"
+                        />
                       </td>
                       <td className="p-2 text-center whitespace-nowrap">
                         <button

--- a/frontend/src/features/admin/UserManager.jsx
+++ b/frontend/src/features/admin/UserManager.jsx
@@ -12,20 +12,12 @@ import ResetPasswordModal from "./ResetPasswordModal";
 import { useTranslation } from "react-i18next";
 import { useContext } from "react";
 import { AppContext } from "../../shared/AppContext";
+import AllergenCheckboxes from "../../components/AllergenCheckboxes.jsx";
+import { useMeta } from "../../shared/meta";
 
 export default function UserManager() {
   const { t } = useTranslation();
-
-  const ALLERGEN_KEYS = [
-    { key: "R", icon: "🥩" },
-    { key: "S", icon: "🐷" },
-    { key: "G", icon: "🐔" },
-    { key: "M", icon: "🥛" },
-    { key: "A", icon: "🍷" },
-    { key: "W", icon: "🌾" },
-    { key: "K", icon: "🧄" },
-    { key: "Y", icon: "🌱" },
-  ];
+  const { pictograms: metaPictograms } = useMeta();
 
   const [users, setUsers] = useState([]);
   const [editingId, setEditingId] = useState(null);
@@ -67,8 +59,23 @@ export default function UserManager() {
   // ────────────────────────────────
   //  Helpers
   // ────────────────────────────────
-  const pictogramLabel = (key) =>
-    t(`Meals.Legend.Pictograms.${key}`, key);
+  const pictogramMap = useMemo(
+    () => new Map((metaPictograms || []).map((p) => [p.key, p])),
+    [metaPictograms]
+  );
+
+  const pictogramDefaults = useMemo(() => {
+    const defaults = {};
+    (metaPictograms || []).forEach(({ key }) => {
+      defaults[key] = false;
+    });
+    return defaults;
+  }, [metaPictograms]);
+
+  const pictogramLabel = (key) => {
+    const meta = pictogramMap.get(key);
+    return meta ? t(meta.tKey, key) : t(`Meals.Legend.Pictograms.${key}`, key);
+  };
 
   // ────────────────────────────────
   //  Editing & Saving
@@ -76,6 +83,7 @@ export default function UserManager() {
   const startEdit = (u) => {
     setEditingId(u._id || u.id);
     setEditForm({
+      ...pictogramDefaults,
       fullName: u.fullName || "",
       username: u.username || "",
       email: u.email || "",
@@ -85,12 +93,17 @@ export default function UserManager() {
       country: u.country || "",
       language: u.language || "",
       Diabetic: u.Diabetic ?? false,
-      ...ALLERGEN_KEYS.reduce(
-        (acc, { key }) => ({ ...acc, [key]: !!u[key] }),
+      ...(metaPictograms || []).reduce(
+        (acc, { key }) => ({ ...acc, [key]: !!u?.[key] }),
         {}
       ),
     });
   };
+
+  useEffect(() => {
+    if (!editingId) return;
+    setEditForm((prev) => ({ ...pictogramDefaults, ...prev }));
+  }, [editingId, pictogramDefaults]);
 
   const cancelEdit = () => {
     setEditingId(null);
@@ -378,23 +391,11 @@ export default function UserManager() {
                         </select>
                       </td>
                       <td className="p-2">
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
-                          {ALLERGEN_KEYS.map(({ key, icon }) => (
-                            <label
-                              key={key}
-                              className="flex items-center gap-1 border border-gray-300 dark:border-gray-700 rounded p-1"
-                            >
-                              <input
-                                type="checkbox"
-                                name={key}
-                                checked={!!editForm[key]}
-                                onChange={handleChange}
-                              />
-                              <span>{icon}</span>
-                              <span>{pictogramLabel(key)}</span>
-                            </label>
-                          ))}
-                        </div>
+                        <AllergenCheckboxes
+                          values={editForm}
+                          onChange={setEditForm}
+                          readOnly={loading}
+                        />
                         <label className="flex items-center text-xs mt-1">
                           <input
                             type="checkbox"
@@ -445,17 +446,22 @@ export default function UserManager() {
                       <td className="p-2">{u.country}</td>
                       <td className="p-2">{u.language}</td>
                       <td className="p-2">
-                       <div className="flex flex-wrap gap-1">
-                          {ALLERGEN_KEYS.filter(({ key }) => u[key]).map(({ key, icon }) => (
-                            <div
-                              key={key}
-                              className="w-8 h-8 flex flex-col items-center justify-center text-xs font-semibold border border-gray-400 dark:border-gray-600 rounded-md"
-                              title={pictogramLabel(key)}
-                            >
-                              <span className="text-base leading-none">{icon}</span>
-                              <span className="leading-none">{key}</span>
-                            </div>
-                          ))}
+                        <div className="flex flex-wrap gap-1">
+                          {(metaPictograms || [])
+                            .filter(({ key }) => u[key])
+                            .map(({ key }) => {
+                              const meta = pictogramMap.get(key) || { icon: key };
+                              return (
+                                <div
+                                  key={key}
+                                  className="w-8 h-8 flex flex-col items-center justify-center text-xs font-semibold border border-gray-400 dark:border-gray-600 rounded-md"
+                                  title={pictogramLabel(key)}
+                                >
+                                  <span className="text-base leading-none">{meta.icon || key}</span>
+                                  <span className="leading-none">{key}</span>
+                                </div>
+                              );
+                            })}
                         </div>
                         {u.Diabetic && (
                           <div className="text-xs text-red-600 dark:text-red-400 mt-1">

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,11 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import './shared/i18n.js' 
+import './shared/i18n.js'
 import App from './App.jsx'
+import { MetaProvider } from './shared/meta.js'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <MetaProvider>
+      <App />
+    </MetaProvider>
   </StrictMode>,
 )

--- a/frontend/src/shared/meta.js
+++ b/frontend/src/shared/meta.js
@@ -1,0 +1,83 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { API } from "./config";
+
+const MetaContext = createContext({
+  version: null,
+  pictograms: [],
+  allergens: [],
+  additives: [],
+  loading: true,
+  error: null,
+  ready: false,
+  refresh: async () => {},
+});
+
+function normalizeMeta(payload = {}) {
+  const normalizeList = (value) => (Array.isArray(value) ? value : []);
+  return {
+    version: typeof payload.version === "string" ? payload.version : null,
+    pictograms: normalizeList(payload.pictograms),
+    allergens: normalizeList(payload.allergens),
+    additives: normalizeList(payload.additives),
+  };
+}
+
+export function MetaProvider({ children }) {
+  const mountedRef = useRef(true);
+  const [state, setState] = useState({
+    loading: true,
+    error: null,
+    data: normalizeMeta(),
+  });
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchMeta = useCallback(async () => {
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const response = await fetch(`${API}/api/meta/init`, { credentials: "include" });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const json = await response.json();
+      if (!mountedRef.current) return;
+      setState({ loading: false, error: null, data: normalizeMeta(json) });
+    } catch (error) {
+      if (!mountedRef.current) return;
+      setState((prev) => ({ ...prev, loading: false, error }));
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMeta();
+  }, [fetchMeta]);
+
+  const value = useMemo(() => {
+    const { loading, error, data } = state;
+    return {
+      ...data,
+      loading,
+      error,
+      ready: !loading && !error,
+      refresh: fetchMeta,
+    };
+  }, [state, fetchMeta]);
+
+  return <MetaContext.Provider value={value}>{children}</MetaContext.Provider>;
+}
+
+export function useMeta() {
+  return useContext(MetaContext);
+}

--- a/shared/constants/meta.js
+++ b/shared/constants/meta.js
@@ -1,0 +1,48 @@
+const PICTOGRAMS = [
+  { key: "R", icon: "🥩", tKey: "Meals.Legend.Pictograms.R", allergenFamily: [] },
+  { key: "S", icon: "🐷", tKey: "Meals.Legend.Pictograms.S", allergenFamily: [] },
+  { key: "G", icon: "🐔", tKey: "Meals.Legend.Pictograms.G", allergenFamily: [] },
+  { key: "M", icon: "🥛", tKey: "Meals.Legend.Pictograms.M", allergenFamily: ["G"] },
+  { key: "A", icon: "🍷", tKey: "Meals.Legend.Pictograms.A", allergenFamily: [] },
+  {
+    key: "W",
+    icon: "🌾",
+    tKey: "Meals.Legend.Pictograms.W",
+    allergenFamily: ["A1", "A2", "A3", "A4", "A5", "A6", "A7"],
+  },
+  { key: "K", icon: "🧄", tKey: "Meals.Legend.Pictograms.K", allergenFamily: [] },
+  { key: "Y", icon: "🌱", tKey: "Meals.Legend.Pictograms.Y", allergenFamily: [] },
+];
+
+const ALLERGENS = [
+  { code: "A1", tKey: "Meals.Legend.Allergens.A1", family: "gluten" },
+  { code: "A2", tKey: "Meals.Legend.Allergens.A2", family: "gluten" },
+  { code: "A3", tKey: "Meals.Legend.Allergens.A3", family: "gluten" },
+  { code: "A4", tKey: "Meals.Legend.Allergens.A4", family: "gluten" },
+  { code: "A5", tKey: "Meals.Legend.Allergens.A5", family: "gluten" },
+  { code: "A6", tKey: "Meals.Legend.Allergens.A6", family: "gluten" },
+  { code: "A7", tKey: "Meals.Legend.Allergens.A7", family: "gluten" },
+  { code: "C", tKey: "Meals.Legend.Allergens.C", family: "egg" },
+  { code: "G", tKey: "Meals.Legend.Allergens.G", family: "milk" },
+  { code: "L", tKey: "Meals.Legend.Allergens.L", family: "celery" },
+];
+
+const ADDITIVES = [
+  { code: "1", tKey: "Meals.Legend.Additives.1" },
+  { code: "2", tKey: "Meals.Legend.Additives.2" },
+  { code: "3", tKey: "Meals.Legend.Additives.3" },
+  { code: "4", tKey: "Meals.Legend.Additives.4" },
+  { code: "5", tKey: "Meals.Legend.Additives.5" },
+  { code: "6", tKey: "Meals.Legend.Additives.6" },
+  { code: "7", tKey: "Meals.Legend.Additives.7" },
+];
+
+const VERSION = "2025.10.24";
+
+module.exports = {
+  PICTOGRAMS,
+  ALLERGENS,
+  ADDITIVES,
+  VERSION,
+};
+module.exports.default = module.exports;

--- a/shared/utils/derivePictograms.js
+++ b/shared/utils/derivePictograms.js
@@ -1,0 +1,24 @@
+const { PICTOGRAMS } = require("../constants/meta");
+
+function derivePictogramsFromAllergens(allergens = [], pictograms = PICTOGRAMS) {
+  if (!Array.isArray(allergens) || !Array.isArray(pictograms)) {
+    return [];
+  }
+  const allergenSet = new Set(allergens.filter(Boolean));
+  if (!allergenSet.size) return [];
+
+  const result = new Set();
+  pictograms.forEach((p) => {
+    if (!Array.isArray(p.allergenFamily) || !p.allergenFamily.length) return;
+    for (const code of p.allergenFamily) {
+      if (allergenSet.has(code)) {
+        result.add(p.key);
+        break;
+      }
+    }
+  });
+  return Array.from(result);
+}
+
+module.exports = { derivePictogramsFromAllergens };
+module.exports.default = module.exports;


### PR DESCRIPTION
## Summary
- introduce shared constants for pictograms, allergens, and additives plus a backend meta init route
- refactor the food schema and admin APIs to use array-based metadata and derive pictograms consistently
- add a meta provider with reusable allergen checkboxes and update admin and settings UIs to consume it

## Testing
- npm --prefix frontend run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68faf699a8a88322a2e6ed4b35462460