### PR TITLE
Enable Russian and remove per-user language limits

### DIFF
--- a/backend/lib/language.js
+++ b/backend/lib/language.js
@@ -1,5 +1,5 @@
 //backend/lib/language.js
-const LANGUAGE_CODES = ["en", "de", "fi", "he"];
+const LANGUAGE_CODES = ["en", "de", "fi", "he", "ru"];
 const DEFAULT_LANGUAGE = "en";
 
 const COUNTRY_LANGUAGE_MAP = {
@@ -15,25 +15,18 @@ function getCountryConfig(countryCode) {
 }
 
 function computeLanguageSettings({ country, preferredLanguage } = {}) {
-  const available = [];
-  const addLanguage = (code) => {
-    if (!code && code !== 0) return;
-    const normalized = String(code).trim().toLowerCase();
-    if (!normalized) return;
-    if (!LANGUAGE_CODES.includes(normalized)) {
-      throw new Error(`Unsupported language code: ${code}`);
-    }
-    if (!available.includes(normalized)) {
-      available.push(normalized);
-    }
-    return normalized;
-  };
-
   const result = {
     country: undefined,
     language: DEFAULT_LANGUAGE,
-    languages: [DEFAULT_LANGUAGE],
   };
+
+  let normalizedPreferred;
+  if (preferredLanguage) {
+    normalizedPreferred = String(preferredLanguage).trim().toLowerCase();
+    if (!LANGUAGE_CODES.includes(normalizedPreferred)) {
+      throw new Error(`Unsupported language code: ${preferredLanguage}`);
+    }
+  }
 
   if (country) {
     const normalizedCountry = String(country).trim().toUpperCase();
@@ -44,44 +37,20 @@ function computeLanguageSettings({ country, preferredLanguage } = {}) {
     }
 
     result.country = normalizedCountry;
-
-    for (const lang of config.languages) {
-      addLanguage(lang);
-    }
-
-    if (preferredLanguage) {
-      const normalizedLang = String(preferredLanguage).trim().toLowerCase();
-      if (!available.includes(normalizedLang)) {
-        throw new Error(
-          `Language ${preferredLanguage} is not available for country ${normalizedCountry}`
-        );
-      }
-      result.language = normalizedLang;
+    if (normalizedPreferred) {
+      result.language = normalizedPreferred;
     } else {
-      const fallback = config.default || config.languages[0] || DEFAULT_LANGUAGE;
-      const normalizedFallback = String(fallback).trim().toLowerCase();
-      if (!available.includes(normalizedFallback)) {
-        addLanguage(normalizedFallback);
-      }
-      result.language = normalizedFallback;
+      const fallback = config.default || DEFAULT_LANGUAGE;
+      result.language = String(fallback).trim().toLowerCase();
     }
-  } else if (preferredLanguage) {
-    const normalizedLang = addLanguage(preferredLanguage);
-    result.language = normalizedLang || DEFAULT_LANGUAGE;
+  } else if (normalizedPreferred) {
+    result.language = normalizedPreferred;
   }
 
-  addLanguage(DEFAULT_LANGUAGE);
-
-  result.languages = available.length ? available : [DEFAULT_LANGUAGE];
-  if (!result.languages.includes(result.language)) {
-    result.languages.push(result.language);
-  }
-  if (result.languages[0] !== result.language) {
-    result.languages = [
-      result.language,
-      ...result.languages.filter((code) => code !== result.language),
-    ];
-  }
+  result.languages = [
+    result.language,
+    ...LANGUAGE_CODES.filter((code) => code !== result.language),
+  ];
 
   return result;
 }
@@ -116,9 +85,12 @@ function normalizeUserLanguage(doc = {}) {
   const config = getCountryConfig(rawCountry);
 
   let preferred = derivePreferredLanguage(doc);
+  if (preferred && !LANGUAGE_CODES.includes(preferred)) {
+    preferred = undefined;
+  }
 
   if (config) {
-    if (!preferred || !config.languages.includes(preferred)) {
+    if (!preferred) {
       const fallback = config.default || config.languages[0] || DEFAULT_LANGUAGE;
       preferred = String(fallback).trim().toLowerCase();
     }

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -8,7 +8,13 @@ import NotificationModal from "./NotificationModal";
 import TopRightControls from "./TopRightControls";
 
 
-const LANG_LABELS = { en: "English", de: "German", he: "עברית", fi: "suomi" };
+const LANG_LABELS = {
+  en: "English",
+  de: "German",
+  he: "עברית",
+  fi: "suomi",
+  ru: "русский",
+};
 const COUNTRIES = [
   { code: "DE", name: "Germany", languages: ["de", "en"], flag: "🇩🇪" },
   { code: "FI", name: "Finland", languages: ["fi", "en"], flag: "🇫🇮" },

--- a/frontend/src/features/SettingsModal.jsx
+++ b/frontend/src/features/SettingsModal.jsx
@@ -57,17 +57,10 @@ export default function SettingsModal({ onClose }) {
     []
   );
 
-  const availableLanguages = useMemo(() => {
-    if (user?.languages?.length) {
-      const seen = new Set();
-      return user.languages.filter((code) => {
-        if (!code || seen.has(code)) return false;
-        seen.add(code);
-        return true;
-      });
-    }
-    return Object.keys(LANGUAGE_LABELS);
-  }, [LANGUAGE_LABELS, user]);
+  const availableLanguages = useMemo(
+    () => Object.keys(LANGUAGE_LABELS),
+    [LANGUAGE_LABELS]
+  );
 
   const languageLabel = (code) => LANGUAGE_LABELS[code] || code;
 

--- a/frontend/src/shared/constants.js
+++ b/frontend/src/shared/constants.js
@@ -9,7 +9,13 @@ export const COUNTRIES = [
 
 // 🔍 Dynamically build the language labels
 export const LANG_LABELS = Object.keys(i18n.options.resources).reduce((acc, key) => {
-  const names = { en: "English", he: "Hebrew", de: "German", fi: "Finnish" };
+  const names = {
+    en: "English",
+    he: "Hebrew",
+    de: "German",
+    fi: "Finnish",
+    ru: "Russian",
+  };
   acc[key] = names[key] || key.toUpperCase();
   return acc;
 }, {});


### PR DESCRIPTION
### Motivation
- Allow Russian as a UI language and expose it to users in the Settings UI so translations in `ru.json` are usable.
- Remove per-user language restrictions so the Settings language selector shows every supported language rather than being limited by `user.languages` or country-specific maps.
- Ensure backend language validation and normalization recognizes `ru` and orders languages with the preferred language first.

### Description
- Add `ru` to supported codes in `backend/lib/language.js` and simplify `computeLanguageSettings`/`normalizeUserLanguage` to produce `languages` as the preferred language followed by all other supported codes.
- Change `frontend/src/features/SettingsModal.jsx` so `availableLanguages` always returns `Object.keys(LANGUAGE_LABELS)` and include the Russian label in the modal's `LANGUAGE_LABELS` map.
- Add Russian to frontend language label utilities in `frontend/src/shared/constants.js` and update `frontend/src/components/Register.jsx` to show `ru` in the registration language choices.
- Modified files: `backend/lib/language.js`, `frontend/src/features/SettingsModal.jsx`, `frontend/src/shared/constants.js`, and `frontend/src/components/Register.jsx`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a7bb6d9f483229f8c5abe61390d0e)