### PR TITLE
Fix mediasoup transport announced address selection in local Docker flow

### DIFF
--- a/backend/rtc/transports.js
+++ b/backend/rtc/transports.js
@@ -1,38 +1,65 @@
 // backend/rtc/transports.js
 const { getOrCreateRouter } = require("./routers");
 
+function normalizeAnnouncedAddress(raw) {
+  if (!raw) return null;
+
+  const v = String(raw).trim();
+  if (!v) return null;
+
+  // ICE candidates with 0.0.0.0 / :: are not reachable from browsers.
+  if (v === "0.0.0.0" || v === "::") return null;
+
+  // Localhost is valid in many setups, but 127.0.0.1 is the most predictable
+  // value for host-browser + dockerized backend development.
+  if (v === "localhost" || v === "::1") return "127.0.0.1";
+
+  return v;
+}
+
 /**
  * IMPORTANT:
- * In Docker bridge mode you MUST announce a reachable host.
- *
- * For your localhost dev:
- *   MEDIASOUP_ANNOUNCED_IP=localhost
- *
- * For VPS:
- *   MEDIASOUP_ANNOUNCED_IP=YOUR_PUBLIC_IP
+ * In Docker bridge mode you MUST announce a host that the browser can reach.
+ * Priority:
+ *   1. MEDIASOUP_ANNOUNCED_IP / MEDIASOUP_ANNOUNCED_ADDRESS
+ *   2. value inferred from current socket request host
  */
-function getListenIps() {
-  const announcedIp =
+function getAnnouncedAddress(requestAnnouncedAddress) {
+  const fromEnv =
     process.env.MEDIASOUP_ANNOUNCED_IP ||
     process.env.MEDIASOUP_ANNOUNCED_ADDRESS;
 
-  if (!announcedIp) {
-    throw new Error("MEDIASOUP_ANNOUNCED_IP is not set");
+  const announcedAddress =
+    normalizeAnnouncedAddress(fromEnv) ||
+    normalizeAnnouncedAddress(requestAnnouncedAddress);
+
+  if (!announcedAddress) {
+    throw new Error(
+      "Unable to determine mediasoup announced address. Set MEDIASOUP_ANNOUNCED_IP."
+    );
   }
 
-  return [
-    {
-      ip: "0.0.0.0",
-      announcedIp,
-    },
-  ];
+  return announcedAddress;
 }
 
-async function createWebRtcTransport({ roomId }) {
+async function createWebRtcTransport({ roomId, announcedAddress: requestAnnouncedAddress }) {
   const router = await getOrCreateRouter(String(roomId));
+  const announcedAddress = getAnnouncedAddress(requestAnnouncedAddress);
 
   const transport = await router.createWebRtcTransport({
-    listenIps: getListenIps(),
+    // listenInfos is the recommended API in current mediasoup versions.
+    listenInfos: [
+      {
+        protocol: "udp",
+        ip: "0.0.0.0",
+        announcedAddress,
+      },
+      {
+        protocol: "tcp",
+        ip: "0.0.0.0",
+        announcedAddress,
+      },
+    ],
     enableUdp: true,
     enableTcp: true,
     preferUdp: true,

--- a/backend/sockets/index.js
+++ b/backend/sockets/index.js
@@ -283,8 +283,15 @@ module.exports = function setupSockets(io) {
         if (direction === "recv" && peer.recvTransportId)
           throw new Error("Recv transport already exists");
     
+        const forwardedHost = socket.handshake?.headers?.["x-forwarded-host"];
+        const hostHeader = (Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost)
+          || socket.handshake?.headers?.host
+          || "";
+        const announcedAddress = String(hostHeader).split(",")[0].trim().split(":")[0];
+
         const { transport } = await createWebRtcTransport({
-          roomId: socket.data.roomId
+          roomId: socket.data.roomId,
+          announcedAddress,
         });
     
         peer.transports.set(transport.id, transport);


### PR DESCRIPTION
### Motivation
- ICE failed in Docker/localhost dev because mediasoup was forced to use a single env var and sometimes advertised non-reachable candidates (e.g. `0.0.0.0`, `::`, `localhost`) causing browser WebRTC ICE failures.
- Improve announced address selection so the server advertises a host the browser can actually reach, with a pragmatic fallback from the Socket.IO handshake when env config is missing or unsuitable.

### Description
- Add `normalizeAnnouncedAddress` to sanitize and map unsafe values (`localhost`/`::1` → `127.0.0.1`, reject `0.0.0.0`/`::`).
- Add `getAnnouncedAddress` to prefer `MEDIASOUP_ANNOUNCED_IP` / `MEDIASOUP_ANNOUNCED_ADDRESS` and fall back to a request-provided host when available, throwing if none is usable.
- Change `createWebRtcTransport` to accept an optional `announcedAddress` from the caller and create transports using `listenInfos` with the resolved `announcedAddress` for both UDP and TCP.
- Update the Socket.IO `rtc:createWebRtcTransport` handler to derive a host fallback from the handshake (`x-forwarded-host` / `host`) and pass it into `createWebRtcTransport`, preserving the one-send/one-recv transport enforcement and existing transport option payload.

### Testing
- Syntax/type checks: `node --check backend/rtc/transports.js` succeeded and `node --check backend/sockets/index.js` succeeded.
- Unit/test run: `npm --prefix backend test -- --runInBand` was executed but the test suite failed to run in this environment because `mongodb-memory-server` attempted to download a MongoDB binary and received HTTP 403, causing failures unrelated to the mediasoup changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69984b33dfc88322bc5ec30ff8ddec30)